### PR TITLE
[#48] feat : 리액트 Portal 사용하여 모달 리팩토링

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,8 +11,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko">
       <body>
-        <QueryProvider>{children}</QueryProvider>
-        <div id="portal"></div> {/* 모달을 위한 요소 */}
+        <QueryProvider>
+          {children}
+          <div id="portal"></div>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="ko">
       <body>
         <QueryProvider>{children}</QueryProvider>
+        <div id="portal"></div> {/* 모달을 위한 요소 */}
       </body>
     </html>
   );

--- a/components/@common/Modal/index.tsx
+++ b/components/@common/Modal/index.tsx
@@ -1,10 +1,15 @@
 "use client";
+import ReactDOM from "react-dom";
 import * as styles from "./style.css";
+
 const Modal = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <div className={styles.wrapper}>
-      <div className={styles.container}>{children}</div>
-    </div>
+  return ReactDOM.createPortal(
+    <>
+      <div className={styles.wrapper}>
+        <div className={styles.container}>{children}</div>
+      </div>
+    </>,
+    document.getElementById("portal") as HTMLElement,
   );
 };
 

--- a/hooks/useModal.tsx
+++ b/hooks/useModal.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 
 export const useModal = () => {
-  const [isModalOpen, setIsModalOpen] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const openModalFunc = (type: string) => {
-    setIsModalOpen(type);
+  const openModalFunc = () => {
+    setIsModalOpen(true);
   };
   const closeModalFunc = () => {
-    setIsModalOpen("");
+    setIsModalOpen(false);
   };
 
   return { isModalOpen, openModalFunc, closeModalFunc };


### PR DESCRIPTION
## 📌 관련 이슈
- close #48 

## 💻 주요 변경 사항
- 리액트 포탈 사용해서 모달 컴포넌트 리팩토링 했습니다.
- Portals는 부모 컴포넌트의 내부 DOM이 아니라, 미리 지정해둔 DOM에서 렌더링 할 수 있는 기능이라고 하네요.
- body 태그 가장 밑에 랜더링하게 설정했습니다.
- 포탈 관련한 설명은 링크 첨부하겠습니다.
+ 저번 플젝때처럼 z-index꼬이지 않게...하려면 적용해도 좋을 거 같아서 적용했어요!


## 📸 스크린샷
<img width="227" alt="스크린샷 2024-01-30 오후 4 21 28" src="https://github.com/ppp-team/my-pet-log/assets/72639353/c412563f-95c2-4efc-874d-449635323991">

## 📣 기타 문의(선택)
- https://han-py.tistory.com/598