### PR TITLE
[#63] feat : 프로필 관리 페이지 구현, 비밀번호 변경 페이지 리팩토링

### DIFF
--- a/app/(settingsMenu)/(Account)/password/page.tsx
+++ b/app/(settingsMenu)/(Account)/password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SubmitHandler, useForm, Controller } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { CURRENT_PASSWORD_RULES, ERROR_MESSAGE, NEW_PASSWORD_RULES, PLACEHOLDER } from "@/constants/inputConstant";
 
 interface IFormInput {
@@ -27,42 +27,27 @@ const validatePasswordMatch = (value: string, newPassword: string) => {
 
 const Page = () => {
   const {
-    control,
+    register,
     handleSubmit,
     formState: { errors },
     watch,
-  } = useForm<IFormInput>();
-  const onSubmit: SubmitHandler<IFormInput> = (data) => console.log(data);
+  } = useForm<IFormInput>({ mode: "onChange" });
 
+  const onSubmit: SubmitHandler<IFormInput> = (data) => console.log(data);
   const newPassword = watch("newPassword");
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <label htmlFor="password">비밀번호</label>
-      <Controller
-        control={control}
-        name="password"
-        rules={CURRENT_PASSWORD_RULES}
-        render={({ field }) => <input {...field} type="password" placeholder={PLACEHOLDER.currentPassword} />}
-      ></Controller>
+      <label>비밀번호</label>
+      <input {...register("password", CURRENT_PASSWORD_RULES)} type="password" placeholder={PLACEHOLDER.currentPassword} />
       {errors.password && <span>{errors.password.message}</span>}
 
-      <label htmlFor="newPassword">새 비밀번호</label>
-      <Controller
-        control={control}
-        name="newPassword"
-        rules={NEW_PASSWORD_RULES}
-        render={({ field }) => <input {...field} type="password" placeholder={PLACEHOLDER.newPassword} />}
-      ></Controller>
+      <label>새 비밀번호</label>
+      <input {...register("newPassword", NEW_PASSWORD_RULES)} type="password" placeholder={PLACEHOLDER.newPassword} />
       {errors.newPassword && <span>{errors.newPassword.message}</span>}
 
-      <label htmlFor="newPasswordCheck">새 비밀번호 확인</label>
-      <Controller
-        control={control}
-        name="newPasswordCheck"
-        rules={newPasswordCheckRules(newPassword)}
-        render={({ field }) => <input {...field} type="password" placeholder={PLACEHOLDER.confirmNewPassword} />}
-      ></Controller>
+      <label>새 비밀번호 확인</label>
+      <input {...register("newPasswordCheck", newPasswordCheckRules(newPassword))} type="password" placeholder={PLACEHOLDER.confirmNewPassword} />
       {errors.newPasswordCheck && <span>{errors.newPasswordCheck.message}</span>}
 
       <button type="submit">확인</button>

--- a/app/(settingsMenu)/(Account)/profile/page.tsx
+++ b/app/(settingsMenu)/(Account)/profile/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { SubmitHandler, useForm } from "react-hook-form";
+import { NICKNAME_RULES, PLACEHOLDER } from "@/constants/inputConstant";
+import { useState } from "react";
+import Image from "next/image";
+import basicIcon from "@/assets/invite-petcard.svg?url";
+
+interface IFormInput {
+  nickname: string;
+  image: File[];
+}
+
+const Page = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<IFormInput>({ mode: "onChange" });
+  const [imagePreview, setImagePreview] = useState<string>(basicIcon);
+
+  const onSubmit: SubmitHandler<IFormInput> = (data) => console.log(data);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    if (files[0]) {
+    }
+    setImagePreview(URL.createObjectURL(files[0]));
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <label htmlFor="image">
+        <Image src={imagePreview} alt="Preview" width={50} height={50} />
+      </label>
+      <input id="image" type="file" accept="image/*" {...register("image")} onChange={handleImageChange} style={{ display: "none" }} />
+
+      <label>닉네임</label>
+      <input {...register("nickname", NICKNAME_RULES)} placeholder={PLACEHOLDER.nickname} />
+      {errors.nickname && <span>{errors.nickname.message}</span>}
+
+      <button type="submit">확인</button>
+    </form>
+  );
+};
+
+export default Page;

--- a/assets/no-profile.svg
+++ b/assets/no-profile.svg
@@ -1,9 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="Frame 1410113908">
-<rect width="24" height="24" rx="12" fill="#CCCCCC"/>
-<g id="Group">
-<path id="Vector" d="M19.7274 20.447C19.2724 19.171 18.2674 18.044 16.8704 17.24C15.4734 16.436 13.7614 16 12.0004 16C10.2394 16 8.52744 16.436 7.13044 17.24C5.73344 18.044 4.72844 19.171 4.27344 20.447" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
-<path id="Vector_2" d="M12 12C14.2091 12 16 10.2091 16 8C16 5.79086 14.2091 4 12 4C9.79086 4 8 5.79086 8 8C8 10.2091 9.79086 12 12 12Z" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
-</g>
-</g>
-</svg>


### PR DESCRIPTION
## 📌 관련 이슈
- close #63 

## 💻 주요 변경 사항
- 비밀번호 변경 페이지 리팩토링(리액트 훅 폼 필요없는 부분 삭제하고 코드 깔끔하게..)
- 컨트롤러 사용 안하고 레지스터 사용했습니다
- 프로필 변경 페이지도 구현 완료했습니다

## 📸 스크린샷
https://github.com/ppp-team/my-pet-log/assets/72639353/e589422e-701b-444a-a7d3-15f35a64025c

## 📣 기타 문의(선택)
- 디자인 추후 입힐 예정입니돠
