### PR TITLE
[#82] fix : 캘린더 닫을 시 날짜 반영 안 되는 이슈

### DIFF
--- a/app/diary/edit/page.tsx
+++ b/app/diary/edit/page.tsx
@@ -13,6 +13,7 @@ const EditPage = () => {
     register,
     formState: { errors },
     setValue,
+    getValues,
     watch,
     handleSubmit,
   } = useForm({ mode: "onChange" });
@@ -40,7 +41,7 @@ const EditPage = () => {
           {errors["title"] && <p className={styles.error}>{errors["title"].message?.toString()}</p>}
         </div>
 
-        <DateInput register={register} setValue={setValue} />
+        <DateInput register={register} setValue={setValue} getValue={getValues} />
         <ImageInput register={register} setValue={setValue} />
         <VideoInput register={register} setValue={setValue} />
 

--- a/app/healthlog/(route)/edit/page.tsx
+++ b/app/healthlog/(route)/edit/page.tsx
@@ -23,7 +23,6 @@ const Page = () => {
     register,
     handleSubmit,
     setValue,
-    getValues,
     // formState: { errors },
   } = useForm();
 
@@ -87,7 +86,7 @@ const Page = () => {
         <p className={styles.title}>건강수첩 작성하기</p>
         <form onSubmit={handleSubmit(onSubmit)} className={styles.formItems}>
           <div className={styles.inputWrapper}>
-            <DateInput register={register} setValue={setValue} getValue={getValues} />
+            <DateInput register={register} setValue={setValue} />
           </div>
           <div className={styles.inputWrapper}>
             <label>담당 메이트</label>

--- a/app/healthlog/(route)/edit/page.tsx
+++ b/app/healthlog/(route)/edit/page.tsx
@@ -23,6 +23,7 @@ const Page = () => {
     register,
     handleSubmit,
     setValue,
+    getValues,
     // formState: { errors },
   } = useForm();
 
@@ -86,7 +87,7 @@ const Page = () => {
         <p className={styles.title}>건강수첩 작성하기</p>
         <form onSubmit={handleSubmit(onSubmit)} className={styles.formItems}>
           <div className={styles.inputWrapper}>
-            <DateInput register={register} setValue={setValue} />
+            <DateInput register={register} setValue={setValue} getValue={getValues} />
           </div>
           <div className={styles.inputWrapper}>
             <label>담당 메이트</label>

--- a/components/@common/DateInput/index.tsx
+++ b/components/@common/DateInput/index.tsx
@@ -2,18 +2,23 @@ import * as styles from "@/app/diary/edit/style.css";
 import { InputProps } from "@/components/Diary/ImageInput";
 import VanillaCalendar from "@/components/@common/VanillaCalendar";
 import { getPrettyTime, getPrettyToday } from "@/utils/getPrettyToday";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Options } from "vanilla-calendar-pro";
+import { FieldValues, UseFormGetValues } from "react-hook-form";
 
-const DateInput = ({ register, setValue }: InputProps) => {
+interface DateInputProps extends InputProps {
+  getValue: UseFormGetValues<FieldValues>;
+}
+const DateInput = ({ register, setValue, getValue }: DateInputProps) => {
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const [dateValue, setDateValue] = useState(getPrettyToday());
+  const [timeValue, setTimeValue] = useState(getPrettyTime());
 
   const options: Options = {
     settings: {
       selected: {
-        dates: [getPrettyToday()],
-        time: getPrettyTime(),
+        dates: [getValue("date")],
+        time: getValue("time"),
       },
       selection: {
         time: true,
@@ -21,22 +26,28 @@ const DateInput = ({ register, setValue }: InputProps) => {
     },
     actions: {
       changeTime(e, self) {
-        setValue("time", ` ${self.selectedTime}`);
+        setValue("time", `${self.selectedTime}`);
+        // setTimeValue(getValue("time"));
       },
       clickDay(e, self) {
         if (!self.selectedDates[0]) return;
 
         setValue("date", `${self.selectedDates[0]}`);
+        setDateValue(getValue("date"));
       },
     },
   };
+
+  useEffect(() => {
+    setTimeValue(getValue("time"));
+  }, [isCalendarOpen]);
 
   return (
     <div className={styles.inputWrapper}>
       <label className={styles.label}>날짜</label>
       <div style={{ display: "flex", gap: "1rem" }} onClick={() => setIsCalendarOpen(!isCalendarOpen)}>
-        <input className={styles.input} value={getPrettyToday()} readOnly {...register("date")} />
-        <input className={styles.input} value={getPrettyTime()} suppressHydrationWarning readOnly {...register("time")} />
+        <input className={styles.input} value={dateValue} readOnly {...register("date")} />
+        <input className={styles.input} value={timeValue} suppressHydrationWarning readOnly {...register("time")} />
       </div>
       {isCalendarOpen && <VanillaCalendar config={options} style={{ minWidth: "20rem", width: "100%" }} />}
     </div>


### PR DESCRIPTION
## 📌 관련 이슈
- close #82 

## 💻 주요 변경 사항
- 캘린더를 닫으면 선택한 날짜에 상관없이 '오늘날짜'로 바뀌는 이슈 해결
- 시간은 닫을 때 깜빡이는 현상이 있는데, 깜빡이는 걸 해결하면 스크롤이 안 되고 스크롤을 하려면 깜빡임이 생길 수 밖에 없어요.
깜빡이는 건 티가 잘 안 나서 일단 스크롤을 선택했습니다.
캘린더의 스크롤 반영이 useState의 setState와 상충하는 부분이 있는 것 같아요(라이브러리 한계)

자세한 사항은 코드에 적어놓을게요.

소희님의 healthlog/edit의 DateInput만 살짝 건드렸습니다!

## 📸 스크린샷

https://github.com/ppp-team/my-pet-log/assets/144668146/4c935c67-0727-4ea1-af75-aae7b30dcf13



- 깜빡임을 해결하여 스크롤이 안 되는 모습입니다.

https://github.com/ppp-team/my-pet-log/assets/144668146/6fec7c34-caf7-472f-bf33-3e111190d04a




## 📣 기타 문의(선택)
- 깜빡임까지 완벽하게 해결하려면 다른 time picker 라이브러리를 도입해야 할 것 같아요..아마도
