### PR TITLE
[#149] refactor : 닉네임 변경 로직 util 함수로 분리

### DIFF
--- a/app/settings/(account)/profile/page.tsx
+++ b/app/settings/(account)/profile/page.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { SubmitHandler, useForm } from "react-hook-form";
-import { CONFIRM_MESSAGE, ERROR_MESSAGE, NICKNAME_RULES, PLACEHOLDER } from "@/app/_constants/inputConstant";
+import { ERROR_MESSAGE, NICKNAME_RULES, PLACEHOLDER } from "@/app/_constants/inputConstant";
 import { useEffect } from "react";
 import * as styles from "@/app/settings/(account)/profile/page.css";
 import mockData from "./mockData.json"; //추후 삭제
 import cameraIcon from "@/public/icons/camera.svg?url";
 import Image from "next/image";
-import removeSpaces from "@/app/_utils/removeSpaces";
-import ErrorMessage from "@/app/_components/ErrorMessage";
-import ConfirmMessage from "@/app/_components/ConfirmMessage/ConfirmMessage";
 import NoProfileImage from "@/public/images/person-profile-default.svg?url";
+import { checkNickname } from "@/app/settings/_utils/checkNickname";
+import { getNicknameState } from "@/app/settings/_utils/getNicknameState";
 
 interface IFormInput {
   nickname: string;
@@ -28,6 +27,7 @@ const Page = () => {
     setError,
   } = useForm<IFormInput>({ mode: "onChange" });
   const nicknameValue = watch("nickname");
+  const isNicknameConfirmed = watch("isNicknameConfirmed");
 
   // 리액트 훅 폼 사용해서 닉네임, 프로필, 이메일 받아오도록 추후 수정
   useEffect(() => {
@@ -36,67 +36,21 @@ const Page = () => {
     setValue("isNicknameConfirmed", false);
   }, [setValue]);
 
-  useEffect(() => {
-    // 사용자가 닉네임을 변경할 때마다 실행(전에는 한번 유효성 검사되고 다시 닉네임 변경하면 유효성 검사를 다시 해야하는데 초기화를 안해서 안하더라구요)
-    setValue("isNicknameConfirmed", false);
-  }, [nicknameValue, setValue]);
-
+  // 이미지 업로드
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files) return;
     setValue("image", URL.createObjectURL(files[0]));
   };
 
-  const onClickCheckNickname = () => {
-    //닉네임 입력 시 모든 공백 제거
-    const removeSpacesNickname = removeSpaces(watch("nickname"));
-    setValue("nickname", removeSpacesNickname);
-
-    if (removeSpacesNickname.length > 10) {
-      return;
-    }
-
-    if (removeSpacesNickname === "") {
-      // 공백만 입력했을 때
-      setError("nickname", { type: "required", message: ERROR_MESSAGE.nicknameRequired });
-      return;
-    }
-
-    // 닉네임 중복 에러메세지 테스트
-    const isConfirmed = true;
-
-    // 닉네임 중복 api
-    if (!isConfirmed) {
-      //닉네임 중복 시
-      setError("nickname", { type: "duplicated", message: ERROR_MESSAGE.nicknameDuplicate });
-    } else {
-      //닉네임 중복 x
-      setValue("isNicknameConfirmed", true);
-    }
+  // 닉네임 중복 검사
+  const handleCheckNickname = () => {
+    checkNickname(setValue, setError, watch);
   };
+  const { style, message } = getNicknameState(isNicknameConfirmed, errors);
 
-  const getNicknameState = () => {
-    if (watch("isNicknameConfirmed")) {
-      return {
-        style: styles.inputConfirmStyle,
-        component: <ConfirmMessage message={CONFIRM_MESSAGE.nicknameValid} />,
-      };
-    } else if (errors?.nickname) {
-      return {
-        style: styles.inputErrorStyle,
-        component: <ErrorMessage message={errors?.nickname?.message} />,
-      };
-    } else {
-      return {
-        style: null,
-        component: null,
-      };
-    }
-  };
-
+  //폼 제출 시
   const onSubmit: SubmitHandler<IFormInput> = (data) => {
-    const isNicknameConfirmed = watch("isNicknameConfirmed");
-
     if (isNicknameConfirmed) {
       // 중복 검사 완료일 경우에만 submit api 통신
       alert("성공");
@@ -124,12 +78,21 @@ const Page = () => {
 
       <label className={styles.label}>닉네임*</label>
       <div className={styles.nicknameContainer}>
-        <input className={`${styles.nickname} ${getNicknameState().style}`} {...register("nickname", NICKNAME_RULES)} placeholder={PLACEHOLDER.nickname} />
-        <button className={styles.checkNicknameButton} type="button" onClick={onClickCheckNickname}>
+        <input
+          className={`${styles.nickname} ${style}`}
+          placeholder={PLACEHOLDER.nickname}
+          {...register("nickname", {
+            ...NICKNAME_RULES,
+            onChange: () => {
+              setValue("isNicknameConfirmed", false);
+            },
+          })}
+        />
+        <button className={styles.checkNicknameButton} type="button" onClick={handleCheckNickname}>
           중복확인
         </button>
       </div>
-      {getNicknameState()?.component}
+      {message}
       <span className={styles.length}>{nicknameValue?.length} / 10</span>
 
       <button className={styles.button} type="submit">

--- a/app/settings/_utils/checkNickname.ts
+++ b/app/settings/_utils/checkNickname.ts
@@ -1,0 +1,30 @@
+import { UseFormSetValue, UseFormSetError, UseFormWatch } from "react-hook-form";
+
+interface FormValues {
+  nickname: string;
+  image: string;
+  isNicknameConfirmed: boolean;
+}
+
+export const checkNickname = (setValue: UseFormSetValue<FormValues>, setError: UseFormSetError<FormValues>, watch: UseFormWatch<FormValues>) => {
+  const nickname = watch("nickname").replace(/\s+/g, "");
+  setValue("nickname", nickname);
+
+  if (nickname.length > 10) {
+    setError("nickname", { type: "maxLength", message: "닉네임은 10자를 초과할 수 없습니다." });
+    return;
+  }
+
+  if (nickname === "") {
+    setError("nickname", { type: "required", message: "닉네임을 입력해주세요." });
+    return;
+  }
+
+  // 닉네임 중복 검사 로직
+  const isConfirmed = true; // 실제로는 API 호출 결과 사용
+  if (!isConfirmed) {
+    setError("nickname", { type: "duplicated", message: "이미 사용 중인 닉네임입니다." });
+  } else {
+    setValue("isNicknameConfirmed", true);
+  }
+};

--- a/app/settings/_utils/getNicknameState.tsx
+++ b/app/settings/_utils/getNicknameState.tsx
@@ -1,0 +1,30 @@
+import { FieldErrors } from "react-hook-form";
+import { inputConfirmStyle, inputErrorStyle } from "@/app/settings/(account)/profile/page.css";
+import ErrorMessage from "@/app/_components/ErrorMessage";
+import ConfirmMessage from "@/app/_components/ConfirmMessage/ConfirmMessage";
+import { CONFIRM_MESSAGE } from "@/app/_constants/inputConstant";
+
+interface FormValues {
+  nickname: string;
+  image: string;
+  isNicknameConfirmed: boolean;
+}
+
+export const getNicknameState = (isNicknameConfirmed: boolean, errors: FieldErrors<FormValues>) => {
+  if (isNicknameConfirmed) {
+    return {
+      style: inputConfirmStyle,
+      message: <ConfirmMessage message={CONFIRM_MESSAGE.nicknameValid} />,
+    };
+  } else if (errors.nickname) {
+    return {
+      style: inputErrorStyle,
+      message: <ErrorMessage message={errors.nickname.message} />,
+    };
+  } else {
+    return {
+      style: null,
+      message: null,
+    };
+  }
+};


### PR DESCRIPTION
## 📌 관련 이슈
- close #149 

## 💻 주요 변경 사항
- 닉네임 중복검사, 닉네임 에러메시지와 색 상태 관련 함수를 util함수로 분리🧚🏻
- 프로필 인풋, 닉네임 인풋이렇게 컴포넌트를 만들까하다가 코드가 그렇게 길진 않아서 그냥 간단한 기능을 settings의 util로 분리했어염

## 📸 스크린샷

## 📣 기타 문의(선택)
-
