### PR TITLE
[#178] feat : select pet api 연동

### DIFF
--- a/app/_api/diary/index.ts
+++ b/app/_api/diary/index.ts
@@ -2,8 +2,11 @@
 
 import instance from "@/app/_api/axios";
 import { Diary, GetDiaryListRequest } from "@/app/_types/diary/type";
+import { cookies } from "next/headers";
 
-export const postDiary = async ({ petId, data }: { petId: number; data: Diary }) => {
+const petId = cookies().get("petId")?.value;
+
+export const postDiary = async ({ data }: { data: Diary }) => {
   try {
     const formData = new FormData();
     const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
@@ -17,7 +20,7 @@ export const postDiary = async ({ petId, data }: { petId: number; data: Diary })
   }
 };
 
-export const getDiaryList = async ({ petId, page, size }: GetDiaryListRequest) => {
+export const getDiaryList = async ({ page, size }: GetDiaryListRequest) => {
   try {
     const res = await instance.get(`/pets/${petId}/diaries`, { params: { page, size } });
 

--- a/app/_api/pets/index.ts
+++ b/app/_api/pets/index.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import instance from "@/app/_api/axios";
+import { cookies } from "next/headers";
 
 export const getPet = async (petId: number) => {
   try {
@@ -41,6 +42,7 @@ export const editPetRep = async (petId: string) => {
     const response = await instance.post(`/my/pets/${petId}/selectRep`);
 
     if (response.status === 200) {
+      cookies().set("petId", petId);
       return response.data;
     } else {
       throw new Error("User data not found");

--- a/app/_components/SelectPet/index.tsx
+++ b/app/_components/SelectPet/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { getPets } from "@/app/_api/pets";
+import { editPetRep, getPets } from "@/app/_api/pets";
 import * as styles from "@/app/_components/SelectPet/style.css";
 import { PetType, PetsType } from "@/app/_types/petGroup/types";
 import calculateAge from "@/app/_utils/calculateAge";
@@ -8,16 +8,14 @@ import NoPetProfileImage from "@/public/images/pet-profile-default.svg?url";
 import { useQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 const Pet = ({ pet }: { pet: PetType }) => {
-  const router = useRouter();
-
   return (
     <div
       className={styles.container}
       onClick={() => {
-        router.push("/settings");
+        editPetRep(pet.petId);
+        localStorage.setItem("petId", pet.petId);
       }}
     >
       <div className={styles.profile} style={{ backgroundImage: `url(${pet.petImageUrl ?? NoPetProfileImage}` }} />
@@ -31,7 +29,7 @@ const Pet = ({ pet }: { pet: PetType }) => {
     </div>
   );
 };
-const SelectPet = ({ type, data }: { type: string; data: PetsType | null }) => {
+const SelectPet = ({ type, path, data }: { type: string; path: string; data: PetsType | null }) => {
   const { data: pets } = useQuery<PetsType | null>({ queryKey: ["pets"], queryFn: () => getPets(), initialData: data });
 
   return (
@@ -47,7 +45,14 @@ const SelectPet = ({ type, data }: { type: string; data: PetsType | null }) => {
         </div>
 
         <div className={styles.petList}>
-          {pets?.data.map((pet) => pet && <Pet pet={pet} key={pet.petId} />)}
+          {pets?.data.map(
+            (pet) =>
+              pet && (
+                <Link href={path} key={pet.petId}>
+                  <Pet pet={pet} />
+                </Link>
+              ),
+          )}
           <Link href={"/settings/pet-register"} className={styles.container} style={{ justifyContent: "center" }}>
             <div className={styles.addButton}>
               <Image src={AddIcon} alt="add icon" width={16} height={16} className={styles.addIcon} />

--- a/app/_components/SelectPet/index.tsx
+++ b/app/_components/SelectPet/index.tsx
@@ -8,14 +8,17 @@ import NoPetProfileImage from "@/public/images/pet-profile-default.svg?url";
 import { useQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
-const Pet = ({ pet }: { pet: PetType }) => {
+const Pet = ({ pet, path }: { pet: PetType; path: string }) => {
+  const router = useRouter();
   return (
     <div
       className={styles.container}
       onClick={() => {
         editPetRep(pet.petId);
         localStorage.setItem("petId", pet.petId);
+        router.push(path);
       }}
     >
       <div className={styles.profile} style={{ backgroundImage: `url(${pet.petImageUrl ?? NoPetProfileImage}` }} />
@@ -48,9 +51,9 @@ const SelectPet = ({ type, path, data }: { type: string; path: string; data: Pet
           {pets?.data.map(
             (pet) =>
               pet && (
-                <Link href={path} key={pet.petId}>
-                  <Pet pet={pet} />
-                </Link>
+                // <Link href={path} >
+                <Pet pet={pet} path={path} key={pet.petId} />
+                // </Link>
               ),
           )}
           <Link href={"/settings/pet-register"} className={styles.container} style={{ justifyContent: "center" }}>

--- a/app/_components/SelectPet/index.tsx
+++ b/app/_components/SelectPet/index.tsx
@@ -1,71 +1,39 @@
-import AddIcon from "@/public/icons/add.svg?url";
+"use client";
+import { getPets } from "@/app/_api/pets";
 import * as styles from "@/app/_components/SelectPet/style.css";
-import { currentPetAtom } from "@/app/_states/atom";
-import { useRouter } from "next/navigation";
+import { PetType, PetsType } from "@/app/_types/petGroup/types";
+import calculateAge from "@/app/_utils/calculateAge";
+import AddIcon from "@/public/icons/add.svg?url";
 import NoPetProfileImage from "@/public/images/pet-profile-default.svg?url";
-import { useAtom } from "jotai";
+import { useQuery } from "@tanstack/react-query";
 import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 
-const PET_DATA = [
-  {
-    id: 1,
-    name: "해피",
-    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Golde33443.jpg/560px-Golde33443.jpg",
-    gender: "남아",
-    type: "말티즈",
-    age: "11년 2개월",
-  },
-  ,
-  {
-    id: 2,
-    name: "은행",
-    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/Cat_and_mouse.jpg/340px-Cat_and_mouse.jpg",
-    gender: "남아",
-    type: "렉돌",
-    age: "6년 5개월",
-  },
-  {
-    id: 3,
-    name: "나나",
-    image: null,
-    gender: "여아",
-    type: "롭이어",
-    age: "2개월",
-  },
-];
-interface PetData {
-  id: number;
-  name: string;
-  image: string;
-  gender: string;
-  type: string;
-  age: string;
-}
-const Pet = ({ pet }: { pet: PetData }) => {
-  const [currentPet, setCurrentPet] = useAtom(currentPetAtom);
+const Pet = ({ pet }: { pet: PetType }) => {
   const router = useRouter();
 
   return (
     <div
       className={styles.container}
       onClick={() => {
-        setCurrentPet("해피");
-        router.push("/diary");
+        router.push("/settings");
       }}
     >
-      <div className={styles.profile} style={{ backgroundImage: `url(${pet.image ?? NoPetProfileImage}` }} />
+      <div className={styles.profile} style={{ backgroundImage: `url(${pet.petImageUrl ?? NoPetProfileImage}` }} />
 
       <div className={styles.text}>
         <h3 style={{ fontSize: "1.6rem", fontWeight: "700" }}>{pet.name}</h3>
         <p style={{ fontSize: "1.3rem", fontWeight: "500" }}>
-          {pet.type} • {pet.gender} • {pet.age}
+          {pet.breed} • {pet.gender === "MALE" ? "남아" : "여아"} • {calculateAge(pet.birth)}
         </p>
       </div>
     </div>
   );
 };
+const SelectPet = ({ type, data }: { type: string; data: PetsType | null }) => {
+  const { data: pets } = useQuery<PetsType | null>({ queryKey: ["pets"], queryFn: () => getPets(), initialData: data });
 
-const SelectPet = ({ type }: { type: string }) => {
   return (
     <>
       <div className={styles.root}>
@@ -79,12 +47,12 @@ const SelectPet = ({ type }: { type: string }) => {
         </div>
 
         <div className={styles.petList}>
-          {PET_DATA.map((pet) => pet && <Pet pet={pet} key={pet.id} />)}
-          <div className={styles.container} style={{ justifyContent: "center" }}>
+          {pets?.data.map((pet) => pet && <Pet pet={pet} key={pet.petId} />)}
+          <Link href={"/settings/pet-register"} className={styles.container} style={{ justifyContent: "center" }}>
             <div className={styles.addButton}>
-              <Image src={AddIcon} alt="add icon" width={16} height={16} style={{ position: "absolute", top: "50%", left: "50%", transform: "translate(-50%,-50%)" }} />
+              <Image src={AddIcon} alt="add icon" width={16} height={16} className={styles.addIcon} />
             </div>
-          </div>
+          </Link>
         </div>
       </div>
     </>

--- a/app/_components/SelectPet/index.tsx
+++ b/app/_components/SelectPet/index.tsx
@@ -32,8 +32,8 @@ const Pet = ({ pet, path }: { pet: PetType; path: string }) => {
     </div>
   );
 };
-const SelectPet = ({ type, path, data }: { type: string; path: string; data: PetsType | null }) => {
-  const { data: pets } = useQuery<PetsType | null>({ queryKey: ["pets"], queryFn: () => getPets(), initialData: data });
+const SelectPet = ({ type, path }: { type: string; path: string }) => {
+  const { data: pets } = useQuery<PetsType | null>({ queryKey: ["pets"], queryFn: () => getPets() });
 
   return (
     <>

--- a/app/_components/SelectPet/style.css.ts
+++ b/app/_components/SelectPet/style.css.ts
@@ -62,3 +62,10 @@ export const text = style({
   flexDirection: "column",
   gap: "0.8rem",
 });
+
+export const addIcon = style({
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%,-50%)",
+});

--- a/app/_types/diary/type.ts
+++ b/app/_types/diary/type.ts
@@ -23,7 +23,6 @@ export interface Diaries {
 }
 
 export interface GetDiaryListRequest {
-  petId: number;
   page: number | unknown;
   size: number;
 }

--- a/app/diary/_components/DiaryList/index.tsx
+++ b/app/diary/_components/DiaryList/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { getDiaryList } from "@/app/_api/diary";
 import { Diaries } from "@/app/_types/diary/type";
 import EmptyDiaryList from "@/app/diary/_components/EmptyDiaryList";
@@ -36,12 +37,11 @@ const Diary = ({ diary }: { diary: Diaries }) => {
 const PAGE_SIZE = 2;
 
 const DiaryList = () => {
-  const petId = 2;
   const router = useRouter();
-
+  const petId = Number(localStorage.getItem("petId"));
   const { data, fetchNextPage } = useInfiniteQuery({
     queryKey: ["diaries", petId],
-    queryFn: ({ pageParam }) => getDiaryList({ petId, page: pageParam, size: PAGE_SIZE }),
+    queryFn: ({ pageParam }) => getDiaryList({ page: pageParam, size: PAGE_SIZE }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => (lastPage.last ? undefined : lastPageParam + 1),
   });

--- a/app/diary/page.tsx
+++ b/app/diary/page.tsx
@@ -1,13 +1,7 @@
-"use client";
+import dynamic from "next/dynamic";
 
-import DiaryList from "@/app/diary/_components/DiaryList";
-import { currentPetAtom } from "@/app/_states/atom";
-import { useAtom } from "jotai";
-import { redirect } from "next/navigation";
-
+const DiaryList = dynamic(() => import("@/app/diary/_components/DiaryList"), { ssr: false });
 const DiaryPgae = () => {
-  const [currentPet, setCurrentPet] = useAtom(currentPetAtom); //추후에 localStorage로 바꿔야할듯
-  if (!currentPet) return redirect("/diary/select");
   return <DiaryList />;
 };
 

--- a/app/diary/select/page.tsx
+++ b/app/diary/select/page.tsx
@@ -1,10 +1,9 @@
-import { getTestPets } from "@/app/_api/diary";
 import { getPets } from "@/app/_api/pets";
 import SelectPet from "@/app/_components/SelectPet";
 
 const SelectPage = async () => {
   const pets = await getPets();
-  return <SelectPet type="육아일기" data={pets} />;
+  return <SelectPet type="육아일기" path="/diary" data={pets} />;
 };
 
 export default SelectPage;

--- a/app/diary/select/page.tsx
+++ b/app/diary/select/page.tsx
@@ -1,9 +1,17 @@
 import { getPets } from "@/app/_api/pets";
 import SelectPet from "@/app/_components/SelectPet";
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 
 const SelectPage = async () => {
-  const pets = await getPets();
-  return <SelectPet type="육아일기" path="/diary" data={pets} />;
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({ queryKey: ["pets"], queryFn: () => getPets() });
+  const dehydratedState = dehydrate(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <SelectPet type="육아일기" path="/diary" />
+    </HydrationBoundary>
+  );
 };
 
 export default SelectPage;

--- a/app/diary/select/page.tsx
+++ b/app/diary/select/page.tsx
@@ -1,9 +1,10 @@
-"use client";
-
+import { getTestPets } from "@/app/_api/diary";
+import { getPets } from "@/app/_api/pets";
 import SelectPet from "@/app/_components/SelectPet";
 
-const SelectPage = () => {
-  return <SelectPet type="육아일기" />;
+const SelectPage = async () => {
+  const pets = await getPets();
+  return <SelectPet type="육아일기" data={pets} />;
 };
 
 export default SelectPage;

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,9 +3,15 @@ import { NextResponse, NextRequest } from "next/server";
 export function middleware(request: NextRequest) {
   const accessToken = request.cookies.get("accessToken");
   const path = request.nextUrl.pathname;
+  const petId = request.cookies.get("petId");
 
   if (accessToken) {
     if (path === "/" || path.startsWith("/login") || path.startsWith("/signup")) return NextResponse.redirect(new URL("/home", request.url));
+
+    //petId여부에 따라 redirect
+    if (path === "/diary/select" && !petId) return;
+    if (path === "/diary/select" && petId) return NextResponse.redirect(new URL("/diary", request.url));
+    if (path.startsWith("/diary") && !petId) return NextResponse.redirect(new URL("/diary/select", request.url));
   } else {
     if (path === "/" || path.startsWith("/login") || path.startsWith("/signup")) {
     } else return NextResponse.redirect(new URL("/login", request.url));


### PR DESCRIPTION
## 📌 관련 이슈
- close #178 

## 💻 주요 변경 사항
- 반려동물 선택 api 연동
- 서버사이드 렌더링으로 구현했어요
- petId를 cookie와 localStorage 두 군데에서 보관하여 사용합니다.
middleware, api 사용에 cookie를
queryKey 사용에 localStorage를 사용하면 됩니다.
cookie는 서버에서 접근할 수 있다는 장점이 있지만 클라이언트에서 불러오기 불편합니다. (split하고 for문 돌리고 난리남)
그래서 클라이언트 사이드에서는 localStorage를 사용합니다.

- middleware.ts도 petId 여부에 따라 수정했습니다.
diary페이지만 설정했는데 다른 페이지도 해주시길

- 위의 영상은 클라이언트사이드 렌더링, 아래는 서버사이드 렌더링
확실히 서버가 빨라요 ㅇㅁㅇ
## 📸 스크린샷

https://github.com/ppp-team/my-pet-log/assets/144668146/f663e67d-b6b8-4f11-943d-c33ef42b9ae9

https://github.com/ppp-team/my-pet-log/assets/144668146/239cca35-c58f-40f7-8b55-50c122369106



## 📣 기타 문의(선택)
-
