### PR TITLE
[#209] fix : 프로필 변경 api와 기능 리팩토링, 카드 ui 스켈레톤

### DIFF
--- a/app/_api/invitation/index.ts
+++ b/app/_api/invitation/index.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import instance from "@/app/_api/axios";
+import { cookies } from "next/headers";
 
 export const getInvitations = async () => {
   try {
@@ -15,8 +16,9 @@ export const getInvitations = async () => {
 };
 
 export const getMyInvitations = async () => {
+  const petId = cookies().get("petId")?.value;
   try {
-    const response = await instance.get("/my/invitations/my-invitations");
+    const response = await instance.get(`/my/invitations/${petId}/my-invitations`);
 
     if (response.status === 200) {
       return response.data;

--- a/app/_api/users/index.ts
+++ b/app/_api/users/index.ts
@@ -64,6 +64,19 @@ export const putUserProfile = async ({ formData }: { formData: FormData }) => {
   }
 };
 
+export const postUserProfileImage = async ({ formData }: { formData: FormData }) => {
+  try {
+    const response = await instance.post("/users/profile/image", formData, { headers: { "Content-Type": "multipart/form-data" } });
+
+    if (response.status === 200) {
+      return true;
+    }
+  } catch (error: any) {
+    console.error(error.response.data);
+    return null;
+  }
+};
+
 export const postCheckPassword = async (password: string) => {
   try {
     const response = await instance.post("/users/password/validation", {

--- a/app/_components/Toast/index.tsx
+++ b/app/_components/Toast/index.tsx
@@ -16,6 +16,7 @@ const ToastComponent = ({ message, isSuccess }: messageProps) => (
 );
 
 export const showToast = (message: string, isSuccess: boolean) => {
+  toast.dismiss();
   toast(<ToastComponent message={message} isSuccess={isSuccess} />, {
     position: "bottom-center",
     autoClose: 1000,

--- a/app/settings/_components/EmptyMyInvitation/index.tsx
+++ b/app/settings/_components/EmptyMyInvitation/index.tsx
@@ -3,8 +3,8 @@ import { container, title, description } from "./style.css";
 const EmptyMyInvitation = () => {
   return (
     <section className={container}>
-      <p className={title}>초대 받은 내역이 없습니다.</p>
-      <p className={description}>해당 프로필로 온 초대 내역이 없습니다. 새로운 펫메이트를 초대해볼까요?</p>
+      <p className={title}>초대 신청한 내역이 없습니다.</p>
+      <p className={description}>해당 프로필로 보낸 초대 내역이 없습니다. 새로운 펫메이트를 초대해볼까요?</p>
     </section>
   );
 };

--- a/app/settings/_components/Logout/index.tsx
+++ b/app/settings/_components/Logout/index.tsx
@@ -13,6 +13,7 @@ const Logout = () => {
   const logoutMutation = useMutation({
     mutationFn: () => postLogout(),
     onSuccess: () => {
+      localStorage.removeItem("petId");
       router.push("/login");
     },
   });

--- a/app/settings/_components/MyPetInfo/index.tsx
+++ b/app/settings/_components/MyPetInfo/index.tsx
@@ -23,7 +23,15 @@ const MyPetInfo = ({ petInfo, styles }: MyPetProps) => {
 
   return (
     <div className={container}>
-      <Image style={{ border: `3px solid ${profileBorderColor}` }} className={profile} src={getImagePath(petInfo.petImageUrl)} alt="profile icon" width={70} height={70} />
+      <Image
+        style={{ border: `3px solid ${profileBorderColor}` }}
+        className={profile}
+        src={getImagePath(petInfo.petImageUrl)}
+        alt="profile icon"
+        width={70}
+        height={70}
+        priority={true}
+      />
       <div className={info}>
         <span style={{ fontSize: "1.8rem", fontWeight: "600", color: nameTextColor }}>{petInfo.name}</span>
         <span style={{ fontSize: "1.2rem", fontWeight: "500", color: breedTextColor }}>{petInfo.breed}</span>

--- a/app/settings/_components/MyProfile/index.tsx
+++ b/app/settings/_components/MyProfile/index.tsx
@@ -14,19 +14,12 @@ const MyProfile = () => {
     queryFn: () => getMe(),
   });
 
-  const profileImageUrl = data && getImagePath(data.profilePath);
-
   return (
     <div className={styles.container}>
       <div className={styles.title}>마이프로필 관리하기</div>
       {data && (
         <div className={styles.ProfileWrapper}>
-          <div
-            className={styles.profileImg}
-            style={{
-              backgroundImage: `url(${profileImageUrl})`,
-            }}
-          />
+          <Image className={styles.profileImg} src={getImagePath(data.profilePath)} alt="profile image" width={50} height={50} />
           <div>
             <p className={styles.nickname}>{data.nickname}</p>
             <p className={styles.email}>{data.email}</p>

--- a/app/settings/_components/MypetCarousel/index.tsx
+++ b/app/settings/_components/MypetCarousel/index.tsx
@@ -4,7 +4,7 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/pagination";
 import { Pagination } from "swiper/modules";
-import { title, petadd, container, petButton, petMateButton, petInfoWrapper } from "./style.css";
+import { petadd, container, petButton, petMateButton, petInfoWrapper } from "./style.css";
 import "./swiper.css";
 import MyPetInfo from "@/app/settings/_components/MyPetInfo";
 import Image from "next/image";
@@ -14,10 +14,11 @@ import { PetsType } from "@/app/_types/pets/types";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { editPetRep, getPets } from "@/app/_api/pets";
+import Skeleton from "../Skeleton";
 
 const MyPetCarousel = () => {
   const router = useRouter();
-  const { data: pets } = useQuery<PetsType>({
+  const { data: pets, isPending } = useQuery<PetsType>({
     queryKey: ["pets"],
     queryFn: () => getPets(),
   });
@@ -28,9 +29,12 @@ const MyPetCarousel = () => {
     breedTextColor: "var(--White)",
   };
 
+  if (isPending) {
+    return <Skeleton />;
+  }
+
   return (
     <div style={{ marginBottom: (pets?.data?.length ?? 0) > 0 ? "0" : "3.8rem" }}>
-      <div className={title}>마이펫 관리하기</div>
       <Swiper
         slidesPerView={"auto"}
         centeredSlides={true}

--- a/app/settings/_components/Skeleton/index.tsx
+++ b/app/settings/_components/Skeleton/index.tsx
@@ -1,0 +1,11 @@
+import { container, skeleton, skeletonShine } from "./style.css";
+
+const Skeleton = () => (
+  <div className={container}>
+    <div className={skeleton}>
+      <div className={skeletonShine}></div>
+    </div>
+  </div>
+);
+
+export default Skeleton;

--- a/app/settings/_components/Skeleton/style.css.ts
+++ b/app/settings/_components/Skeleton/style.css.ts
@@ -1,0 +1,29 @@
+import { keyframes, style } from "@vanilla-extract/css";
+
+const loadingAnimation = keyframes({
+  "100%": { backgroundPosition: "-100% 0" },
+});
+
+export const container = style({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+});
+
+export const skeleton = style({
+  width: "30.5rem",
+  height: "14.6rem",
+
+  marginBottom: "4.06rem",
+});
+
+export const skeletonShine = style({
+  willChange: "background-position",
+  width: "100%",
+  height: "100%",
+  background: "linear-gradient(120deg, #ffeee4 30%, #ffffff 38%, #ffffff 40%, #ffeee4 48%)",
+  backgroundSize: "200% 100%",
+  borderRadius: "10px",
+  backgroundPosition: "100% 0",
+  animation: `${loadingAnimation} 1s infinite`,
+});

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -8,7 +8,6 @@ import QuestionIcon from "@/public/icons/circle-help.svg?url";
 import MessageIcon from "@/public/icons/message-alt.svg?url";
 import NoticeIcon from "@/public/icons/megaphone.svg?url";
 import MenuList from "@/app/settings/_components/MenuList";
-import { getPets } from "@/app/_api/pets";
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 import { getMe } from "@/app/_api/users";
 import Logout from "@/app/settings/_components/Logout";
@@ -16,13 +15,22 @@ import Logout from "@/app/settings/_components/Logout";
 const Page = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery({ queryKey: ["pets"], queryFn: () => getPets() });
   await queryClient.prefetchQuery({ queryKey: ["me"], queryFn: () => getMe() });
   const dehydratedState = dehydrate(queryClient);
 
   return (
     <>
       <HydrationBoundary state={dehydratedState}>
+        <div
+          style={{
+            margin: "2rem 1.6rem",
+            color: "var(--Gray72)",
+            fontSize: "1.6rem",
+            fontWeight: "600",
+          }}
+        >
+          마이펫 관리하기
+        </div>
         <MypetCarousel />
         <div style={{ padding: "0 1.6rem 1.6rem" }}>
           <Link href="/settings/profile">


### PR DESCRIPTION
## 📌 관련 이슈
- close #209 

## 💻 주요 변경 사항
- 프로필 변경 쪽 api 수정돼서 그거에 맞게 기능 리팩토링 했어요
- 기본프로필도 이제 잘 작동합니다 ㅜㅜ 
- 초대한 내역 api url 수정
- 카드 로딩 스켈레톤을 만들어봤어요. 카드 쪽은 대뜸 발바닥 모양보다 카드 모양의 ui를 보여주면 좋을 거 같아서요

체크해본 로직
- [x] 닉네임만 변경
- [x] 프로필만 변경
- [x] 닉네임 프로필 둘다변경
- [x] 기본프로필로 변경
- [x] 기본프로필로 변경, 닉네임 변경
- [x] 변경 안하고 그냥 확인만 누를 시


## 📸 스크린샷

https://github.com/ppp-team/my-pet-log/assets/72639353/294c63f9-62d0-4093-80bb-7c77b9c4226c



그리고 아직 코드는 안올렸는데 카드 쪽 스켈레톤 ui만들어봤어요..괜찮나요?


https://github.com/ppp-team/my-pet-log/assets/72639353/526b2b88-31a7-4ce7-86d8-1c213d6c0393





## 📣 기타 문의(선택)
- 탈퇴하기 기능도 api가 수정되어야 할 수 있는데 얼른 수정되면 좋겠네요
- 이후에 내가 초대한 내역, 멤버관리, 반려동물 리스트 api 가 수정되면 그거에 맞게 리팩토링 해야합니다.
