### PR TITLE
[#250] refacotr : 반려동물 폼 리팩토링 

### DIFF
--- a/app/_components/PetRegister/index.tsx
+++ b/app/_components/PetRegister/index.tsx
@@ -14,10 +14,11 @@ import DropdownIcon from "@/public/icons/drop-down-icon.svg";
 import OptionalMessage from "./component/OptionalCheck";
 import CloseIcon from "@/public/icons/close.svg?url";
 import BackIcon from "@/public/icons/chevron-left.svg?url";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { postPet } from "@/app/_api/pets";
 import { useModal } from "@/app/_hooks/useModal";
 import Modal from "@/app/_components/Modal";
+import ImageModal from "../Modal/ImageModal";
 
 export interface IFormInput {
   petName: string;
@@ -57,9 +58,17 @@ const PetRegister = () => {
   } = useForm<IFormInput>({ mode: "onTouched" });
 
   const router = useRouter();
-  const handleCloseModal = () => {
-    closeModalFunc();
-    router.push("/settings");
+  const pathname = usePathname();
+
+  const handlePath = () => {
+    if (pathname === "/settings/pet-register") {
+      closeModalFunc();
+      router.push("/settings");
+    }
+    if (pathname === "/pet-register") {
+      closeModalFunc();
+      router.push("/HOME");
+    }
   };
 
   //전체 폼 제출
@@ -340,14 +349,14 @@ const PetRegister = () => {
           </div>
         )}
         마이펫 정보 입력
-        <div className={styles.closeIcon} onClick={() => router.push("/")}>
+        <div className={styles.closeIcon} onClick={() => router.back()}>
           <Image src={CloseIcon} alt="close icon" width={25} height={25} />
         </div>
       </header>
       <form onSubmit={handleSubmit(onSubmit)} className={styles.formContainer}>
         {section === 1 ? section1 : section2}
       </form>
-      {isModalOpen && <Modal text={"등록이 완료되었습니다!"} buttonText={"확인"} onClick={handleCloseModal} onClose={handleCloseModal} />}
+      {isModalOpen && <ImageModal type={"register"} onClick={handlePath} onClose={handlePath} />}
     </>
   );
 };

--- a/app/_components/PetRegister/index.tsx
+++ b/app/_components/PetRegister/index.tsx
@@ -17,8 +17,9 @@ import BackIcon from "@/public/icons/chevron-left.svg?url";
 import { usePathname, useRouter } from "next/navigation";
 import { postPet } from "@/app/_api/pets";
 import { useModal } from "@/app/_hooks/useModal";
-import Modal from "@/app/_components/Modal";
-import ImageModal from "../Modal/ImageModal";
+import ImageModal from "@/app/_components/Modal/ImageModal";
+import GenderSelection from "@/app/_components/PetRegister/component/RadioInput/GenderRadio";
+import NeuteringSelection from "@/app/_components/PetRegister/component/RadioInput/NeuteringRadio";
 
 export interface IFormInput {
   petName: string;
@@ -55,7 +56,7 @@ const PetRegister = () => {
     setValue,
     getValues,
     watch,
-  } = useForm<IFormInput>({ mode: "onTouched" });
+  } = useForm<IFormInput>({ mode: "onSubmit" });
 
   const router = useRouter();
   const pathname = usePathname();
@@ -103,10 +104,11 @@ const PetRegister = () => {
   };
 
   //section1의 유효성 검사(값이 있는 경우에만 버튼클릭가능)
-  let isSectionValid = false;
-  if (getValues() && getValues().petName && getValues().type && getValues().breed) {
-    isSectionValid = true;
-  }
+  // let isSectionValid = false;
+  // if (getValues() && getValues().petName && getValues().type && getValues().breed) {
+  //   isSectionValid = true;
+  // }
+  const isSectionValid = watch("petName") && watch("type") && watch("breed") !== "";
 
   const handleNextSection = () => {
     if (isSectionValid) {
@@ -127,8 +129,10 @@ const PetRegister = () => {
   };
 
   useEffect(() => {
-    setProfileImage(watch("image") || DefaultImage);
-  }, [watch]);
+    if (!watch("image")) {
+      setProfileImage(DefaultImage);
+    }
+  }, [watch("image")]);
 
   //드롭다운 외부 클릭시 닫히게 하기
   useEffect(() => {
@@ -179,11 +183,6 @@ const PetRegister = () => {
   const clearWeightInput = () => {
     setValue("weight", null);
     setIsWeightDisabled((prev) => !prev);
-  };
-
-  //삭제하기 버튼, API호출하는 코드로 수정 예정
-  const handleDelete = () => {
-    console.log("동물 삭제");
   };
 
   const section1 = (
@@ -270,45 +269,11 @@ const PetRegister = () => {
     <>
       {/* 성별 */}
       <label className={styles.label}>성별*</label>
-      <div className={styles.radioContainer}>
-        <div className={styles.leftRadio}>
-          <input type="radio" id="MALE" value="MALE" checked={selectedGender === "MALE"} onClick={() => handleGenderChange("MALE")} {...register("gender", PET_GENDER_RULES)} />
-          <label className={`${styles.radioOption} ${selectedGender === "MALE" && styles.leftSelected}`} htmlFor="MALE">
-            남
-          </label>
-        </div>
-        <div className={styles.rightRadio}>
-          <input
-            type="radio"
-            id="FEMALE"
-            value="FEMALE"
-            checked={selectedGender === "FEMALE"}
-            onClick={() => handleGenderChange("FEMALE")}
-            {...register("gender", PET_GENDER_RULES)}
-          />
-          <label className={`${styles.radioOption} ${selectedGender === "FEMALE" && styles.rightSelected}`} htmlFor="FEMALE">
-            여
-          </label>
-        </div>
-      </div>
-      {errors.gender && <ErrorMessage message={errors.gender.message} />}
+      <GenderSelection selectedGender={selectedGender} handleGenderChange={handleGenderChange} />
 
       {/* 중성화 여부 */}
       <label className={styles.label}>중성화 여부</label>
-      <div className={styles.radioContainer}>
-        <div className={styles.leftRadio}>
-          <input type="radio" id="yes" name="neutering" value="true" checked={selectedNeutering === "true"} onChange={handleNeuteringChange} />
-          <label className={`${styles.radioOption} ${selectedNeutering === "true" && styles.leftSelected}`} htmlFor="yes">
-            했어요
-          </label>
-        </div>
-        <div className={styles.rightRadio}>
-          <input type="radio" id="no" name="neutering" value="false" checked={selectedNeutering === "false"} onChange={handleNeuteringChange} />
-          <label className={`${styles.radioOption} ${selectedNeutering === "false" && styles.rightSelected}`} htmlFor="no">
-            안했어요
-          </label>
-        </div>
-      </div>
+      <NeuteringSelection selectedNeutering={selectedNeutering} handleNeuteringChange={handleNeuteringChange} />
 
       {/* 생일  */}
       <label className={styles.label}>생일</label>
@@ -322,21 +287,18 @@ const PetRegister = () => {
       <label className={styles.label}>몸무게</label>
       <input className={styles.writeInput} {...register("weight", PET_WEIGHT_RULES)} placeholder={PET_PLACEHOLDER.weight} disabled={isWeightDisabled} />
       {errors.weight && <ErrorMessage message={errors.weight.message} />}
-      <OptionalMessage onClearInput={clearWeightInput} message={"모르겠어요"} />
+      <div className={styles.plusMarginWrapper}>
+        <OptionalMessage onClearInput={clearWeightInput} message={"모르겠어요"} />
+      </div>
 
       {/* 동물등록번호 */}
       <label className={styles.label}>동물등록번호</label>
       <input className={styles.writeInput} {...register("registeredNumber", PET_REGISTERNUMBER_RULES)} placeholder={PET_PLACEHOLDER.registeredNumber} />
       {errors.registeredNumber && <ErrorMessage message={errors.registeredNumber.message} />}
 
-      {/* 삭제하기 버튼 */}
-      <div className={styles.deleteButtonWrapper}>
-        <button className={styles.deleteButton} onClick={handleDelete}>
-          동물 삭제하기
-        </button>
-      </div>
-
-      <button className={styles.button}>작성완료</button>
+      <button type="submit" className={styles.button}>
+        작성완료
+      </button>
     </>
   );
 

--- a/app/_components/PetRegister/style.css.ts
+++ b/app/_components/PetRegister/style.css.ts
@@ -99,7 +99,6 @@ export const label = style({
 
 export const input = style({
   padding: "1.3rem 1.8rem",
-  marginBottom: "0.8rem",
 
   borderRadius: "10px",
   border: "1.5px solid #e2e2e2",
@@ -123,12 +122,16 @@ export const writeInput = style([
 
 export const button = style({
   padding: "1.3rem 0",
-  marginTop: "2.4rem",
+  marginTop: "3.1rem",
 
   borderRadius: "30px",
 
-  color: "#fff",
+  color: "var(--White)",
   backgroundColor: "var(--MainOrange)",
+
+  ":disabled": {
+    backgroundColor: "var(--GrayB1)",
+  },
 });
 
 export const inputWrapper = style({
@@ -140,7 +143,6 @@ export const inputWrapper = style({
 export const selectBox = style({
   width: "100%",
   padding: "1.3rem 1.8rem",
-  marginBottom: "0.8rem",
 
   display: "flex",
   justifyContent: "space-between",
@@ -204,7 +206,7 @@ export const dropdownIconOpen = style({
 
 export const optionsList = style({
   width: "100%",
-  padding: "0",
+  maxHeight: "48rem",
 
   display: "flex",
   flexDirection: "column",
@@ -216,6 +218,15 @@ export const optionsList = style({
   borderRadius: "10px",
   boxShadow: "0px 8px 16px 0px rgba(0,0,0,0.2)",
   zIndex: 1,
+
+  overflowY: "auto",
+  "::-webkit-scrollbar": {
+    width: "1px",
+    height: "5px",
+  },
+  "::-webkit-scrollbar-thumb": {
+    background: "var(--White)",
+  },
 });
 
 export const optionButton = style({
@@ -280,8 +291,8 @@ export const radioContainer = style({
   flexDirection: "row",
 
   position: "relative",
-  border: "1.5px var(--LightOrange)",
-  borderRadius: "5px",
+  border: "none",
+  borderRadius: "10px",
 });
 
 export const radioOption = style({
@@ -299,20 +310,21 @@ export const radioOption = style({
 
 export const leftRadio = style({
   width: "100%",
-  border: "solid 1px rgba(0, 0, 0, .15)",
+  border: "solid 1.5px var(--GrayE2)",
+  borderRadius: "10px 0px 0px 10px",
 });
 
 export const rightRadio = style({
+  marginLeft: "-0.1rem",
   width: "100%",
-  border: "solid 1px rgba(0, 0, 0, .15)",
+  border: "solid 1.5px var(--GrayE2)",
+  borderRadius: "0px 10px 10px 0px",
 });
 
 export const leftSelected = style({
   width: "100%",
 
   borderRadius: "10px 0px 0px 10px",
-  border: "1.5px solid var(--MainOrange)",
-
   color: "var(--MainOrange)",
   backgroundColor: "var(--LightOrange)",
 });
@@ -321,21 +333,16 @@ export const rightSelected = style({
   width: "100%",
 
   borderRadius: "0px 10px 10px 0px",
-  border: "1.5px solid var(--MainOrange)",
-
   color: "var(--MainOrange)",
   backgroundColor: "var(--LightOrange)",
 });
 
-export const deleteButtonWrapper = style({});
-export const deleteButton = style({
-  marginTop: "3.2rem",
-  padding: "0.6rem 1.4rem",
-  borderRadius: "5px",
-  border: "1px solid var(--Gray81)",
+export const leftSelectedBorder = style([leftSelected, { border: "1.5px solid var(--MainOrange)", zIndex: 1 }]);
 
-  color: "var(--Gray81)",
+export const rightSelectedBorder = style([rightSelected, { border: "1.5px solid var(--MainOrange)", zIndex: 1 }]);
 
-  fontSize: "1.4rem",
-  fontWeight: 500,
+export const plusMarginWrapper = style({
+  display: "flex",
+  width: "100%",
+  marginTop: "0.6rem",
 });

--- a/app/settings/_components/EditPetRegisterForm/index.tsx
+++ b/app/settings/_components/EditPetRegisterForm/index.tsx
@@ -18,7 +18,6 @@ import { useRouter } from "next/navigation";
 import { deletePet, getPet, putPet } from "@/app/_api/pets";
 import { useModal } from "@/app/_hooks/useModal";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import Modal from "@/app/_components/Modal";
 import { PetType } from "@/app/_types/petGroup/types";
 import GenderSelection from "@/app/_components/PetRegister/component/RadioInput/GenderRadio";
 import NeuteringSelection from "@/app/_components/PetRegister/component/RadioInput/NeuteringRadio";
@@ -28,7 +27,6 @@ import { GuardiansType } from "@/app/_types/guardians/types";
 import { getMe } from "@/app/_api/users";
 import { UserType } from "@/app/_types/user/types";
 import ImageModal from "@/app/_components/Modal/ImageModal";
-import Loading from "@/app/_components/Loading";
 
 export interface IFormInput {
   petName: string;
@@ -46,7 +44,6 @@ export interface IFormInput {
 }
 
 const EditPetRegisterForm = ({ petId }: { petId: number }) => {
-  // const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const { isModalOpen: isConfirmModalOpen, openModalFunc: openConfirmModalFunc, closeModalFunc: closeConfirmModalFunc } = useModal();
   const { isModalOpen: isUnAuthorizedModalOpen, openModalFunc: openUnAuthorizedModalFunc, closeModalFunc: closeUnAuthorizedModalFunc } = useModal();
   const { isModalOpen: isDeleteModalOpen, openModalFunc: openDeleteModalFunc, closeModalFunc: closeDeleteModalFunc } = useModal();
@@ -251,6 +248,8 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
     }
   };
 
+  console.log("petInfo:", petInfo);
+
   const section1 = (
     <>
       <div className={styles.profile}>
@@ -385,7 +384,7 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
           </div>
         )}
         마이펫 정보 입력
-        <div className={styles.closeIcon} onClick={() => router.push("/")}>
+        <div className={styles.closeIcon} onClick={() => router.back()}>
           <Image src={CloseIcon} alt="close icon" width={25} height={25} />
         </div>
       </header>

--- a/app/settings/_components/EditPetRegisterForm/style.css.ts
+++ b/app/settings/_components/EditPetRegisterForm/style.css.ts
@@ -206,7 +206,7 @@ export const dropdownIconOpen = style({
 
 export const optionsList = style({
   width: "100%",
-  padding: "0",
+  maxHeight: "48rem",
 
   display: "flex",
   flexDirection: "column",
@@ -218,6 +218,15 @@ export const optionsList = style({
   borderRadius: "10px",
   boxShadow: "0px 8px 16px 0px rgba(0,0,0,0.2)",
   zIndex: 1,
+
+  overflowY: "auto",
+  "::-webkit-scrollbar": {
+    width: "1px",
+    height: "5px",
+  },
+  "::-webkit-scrollbar-thumb": {
+    background: "var(--White)",
+  },
 });
 
 export const optionButton = style({

--- a/app/settings/_components/EditPetRegisterForm/style.css.ts
+++ b/app/settings/_components/EditPetRegisterForm/style.css.ts
@@ -346,17 +346,19 @@ export const deleteButton = style({
   marginTop: "3.2rem",
   padding: "0.6rem 1.4rem",
   borderRadius: "5px",
-  border: "1px solid var(--White)",
+  border: "1px solid var(--Gray81)",
 
-  color: "var(--White)",
+  color: "var(--Gray81)",
 
   fontSize: "1.4rem",
   fontWeight: 500,
 
-  background: "#FF9999",
+  background: "var(--White)",
 
   ":hover": {
-    background: "var(--Red)",
+    color: "var(--White)",
+    background: "var(--GrayE2)",
+    border: "1px solid var(--GrayE2)",
   },
 });
 

--- a/app/settings/pet-register/page.tsx
+++ b/app/settings/pet-register/page.tsx
@@ -1,0 +1,11 @@
+import PetRegister from "@/app/_components/PetRegister";
+
+const page = () => {
+  return (
+    <div>
+      <PetRegister />
+    </div>
+  );
+};
+
+export default page;


### PR DESCRIPTION
## 📌 관련 이슈
- close #250 

## 💻 주요 변경 사항
- 닫기버튼, 작성완료버튼 폼 타입별 & 최초진입 여부에 따라 각각 다른 경로로 이동하도록 수정
- 이전 작업 브랜치에서 유효한 코드 병합 (컴포넌트 분리, 누락된 CSS 적용)
- 삭제하기 버튼 색상 되돌리기
- 이미지모달 공용컴포넌트로 교체
- 
## 📸 스크린샷

## 📣 기타 문의(선택)
반려동물 폼 남은것 :
- 수정폼, 등록폼 태블릿 반응형
- 수정폼 진입시 등록한 프로필 이미지 보여주기
- 드롭다운 영원히 열리기만 하는 문제

auth폼 남은것 :
- 카카오, 구글 컴포넌트 분리
- 소셜로그인 확인

논의사항 :
- 스크롤바 글로벌CSS ?
