### PR TITLE
[#270] fix : QA피드백 반영2 (혜윤)

### DIFF
--- a/app/(auth)/_components/SignButton/GoogleButton.tsx
+++ b/app/(auth)/_components/SignButton/GoogleButton.tsx
@@ -9,7 +9,6 @@ const GoogleButton = () => {
       await signIn("google", { redirect: true, callbackUrl: "/loginflow" });
     }
   };
-  console.log(session);
 
   return (
     <div>

--- a/app/(auth)/_components/SignButton/KakaoButton.tsx
+++ b/app/(auth)/_components/SignButton/KakaoButton.tsx
@@ -10,7 +10,6 @@ const KakaoButton = () => {
       await signIn("kakao", { redirect: true, callbackUrl: "/loginflow" });
     }
   };
-  console.log(session);
 
   return (
     <div>

--- a/app/_api/pets/index.ts
+++ b/app/_api/pets/index.ts
@@ -5,7 +5,6 @@ import { cookies } from "next/headers";
 
 export const postPet = async ({ formData }: { formData: FormData }) => {
   try {
-    console.log("formData:", formData.get("petImage"));
     const res = await instance.post(`/my/pets`, formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });

--- a/app/_components/PetRegister/component/PetdateInput/index.tsx
+++ b/app/_components/PetRegister/component/PetdateInput/index.tsx
@@ -17,7 +17,6 @@ const PetDateInput = ({ register, setValue, getValue, id }: DateInputProps) => {
   const [dateValue, setDateValue] = useState(getValue(id) || "날짜 선택");
   const [isDisabled, setIsDisabled] = useState(false);
 
-  console.log(register, setValue, getValue, id);
   const options: Options = {
     type: "default",
     settings: {

--- a/app/_components/PetRegister/component/PetdateInput/index.tsx
+++ b/app/_components/PetRegister/component/PetdateInput/index.tsx
@@ -14,9 +14,10 @@ interface DateInputProps {
 }
 const PetDateInput = ({ register, setValue, getValue, id }: DateInputProps) => {
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
-  const [dateValue, setDateValue] = useState("날짜 선택");
+  const [dateValue, setDateValue] = useState(getValue(id) || "날짜 선택");
   const [isDisabled, setIsDisabled] = useState(false);
 
+  console.log(register, setValue, getValue, id);
   const options: Options = {
     type: "default",
     settings: {
@@ -27,8 +28,11 @@ const PetDateInput = ({ register, setValue, getValue, id }: DateInputProps) => {
     actions: {
       clickDay(e, self) {
         if (!self.selectedDates[0]) return;
-        setValue(id, `${self.selectedDates[0]}`);
-        setDateValue(getValue(id) || "");
+
+        if (id === "birthday" || "firstMeet") {
+          setValue(id, `${self.selectedDates[0]}`);
+          setDateValue(getValue(id) || "");
+        }
       },
     },
   };
@@ -39,6 +43,7 @@ const PetDateInput = ({ register, setValue, getValue, id }: DateInputProps) => {
     setIsDisabled((prev) => !prev);
   };
 
+  if (id !== "birthday" && id !== "firstMeet") return null;
   return (
     <div className={styles.inputWrapper}>
       <div style={{ display: "flex", gap: "1rem", position: "relative", marginBottom: "0.6rem" }} onClick={() => setIsCalendarOpen(!isCalendarOpen)}>

--- a/app/_components/PetRegister/index.tsx
+++ b/app/_components/PetRegister/index.tsx
@@ -88,7 +88,6 @@ const PetRegister = () => {
       weight: data.weight === "" ? null : data.weight,
       registeredNumber: data.registeredNumber === "" ? null : data.registeredNumber,
     };
-    console.log("request", request);
 
     const formData = new FormData();
 
@@ -97,7 +96,6 @@ const PetRegister = () => {
     formData.append("petImage", data.image);
 
     // FormData에 데이터가 올바르게 추가되었는지 확인
-    console.log("FormData:", formData.get("petImage"), formData.get("petRequest"));
     const res = await postPet({ formData });
     if (res !== null) {
       queryClient.invalidateQueries({ queryKey: ["pets"] });

--- a/app/_components/PetRegister/index.tsx
+++ b/app/_components/PetRegister/index.tsx
@@ -32,7 +32,7 @@ export interface IFormInput {
   birthday: string | null;
   firstMeet: string | null;
   name: string;
-  weight: number | null;
+  weight: number | null | string;
   registeredNumber: string | null;
   id: string | number | null;
 }
@@ -83,10 +83,10 @@ const PetRegister = () => {
       breed: data.breed,
       gender: data.gender,
       isNeutered: data.neutering,
-      birth: data.birthday,
-      firstMeetDate: data.firstMeet,
-      weight: data.weight,
-      registeredNumber: data.registeredNumber,
+      birth: data.birthday === "날짜 선택" ? null : data.birthday,
+      firstMeetDate: data.firstMeet === "날짜 선택" ? null : data.firstMeet,
+      weight: data.weight === "" ? null : data.weight,
+      registeredNumber: data.registeredNumber === "" ? null : data.registeredNumber,
     };
     console.log("request", request);
 

--- a/app/_components/PetRegister/index.tsx
+++ b/app/_components/PetRegister/index.tsx
@@ -20,6 +20,7 @@ import { useModal } from "@/app/_hooks/useModal";
 import ImageModal from "@/app/_components/Modal/ImageModal";
 import GenderSelection from "@/app/_components/PetRegister/component/RadioInput/GenderRadio";
 import NeuteringSelection from "@/app/_components/PetRegister/component/RadioInput/NeuteringRadio";
+import { useQueryClient } from "@tanstack/react-query";
 
 export interface IFormInput {
   petName: string;
@@ -58,7 +59,9 @@ const PetRegister = () => {
     watch,
   } = useForm<IFormInput>({ mode: "onSubmit" });
 
+  const queryClient = useQueryClient();
   const router = useRouter();
+
   const pathname = usePathname();
 
   const handlePath = () => {
@@ -97,17 +100,11 @@ const PetRegister = () => {
     console.log("FormData:", formData.get("petImage"), formData.get("petRequest"));
     const res = await postPet({ formData });
     if (res !== null) {
+      queryClient.invalidateQueries({ queryKey: ["pets"] });
       return openModalFunc();
     }
-
-    console.log("res", res);
   };
 
-  //section1의 유효성 검사(값이 있는 경우에만 버튼클릭가능)
-  // let isSectionValid = false;
-  // if (getValues() && getValues().petName && getValues().type && getValues().breed) {
-  //   isSectionValid = true;
-  // }
   const isSectionValid = watch("petName") && watch("type") && watch("breed") !== "";
 
   const handleNextSection = () => {

--- a/app/_components/PetRegister/index.tsx
+++ b/app/_components/PetRegister/index.tsx
@@ -99,7 +99,7 @@ const PetRegister = () => {
     const res = await postPet({ formData });
     if (res !== null) {
       queryClient.invalidateQueries({ queryKey: ["pets"] });
-      return openModalFunc();
+      openModalFunc();
     }
   };
 

--- a/app/settings/_components/EditPetRegisterForm/index.tsx
+++ b/app/settings/_components/EditPetRegisterForm/index.tsx
@@ -74,7 +74,6 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["petInfo", petId] });
       queryClient.invalidateQueries({ queryKey: ["pets"] });
-      router.back();
     },
     onError: () => {
       showToast("마이펫 수정에 실패했습니다.", false);
@@ -106,7 +105,6 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["pets"] });
-      router.push("/settings");
     },
     onError: () => {
       showToast("다른 멤버가 있을 때 반려동물을 삭제할 수 없습니다.", false);
@@ -121,7 +119,7 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
     setValue,
     getValues,
     watch,
-  } = useForm<IFormInput>({ mode: "onTouched" });
+  } = useForm<IFormInput>({ mode: "onSubmit" });
 
   //section1의 유효성 검사(값이 있는 경우에만 버튼클릭가능)
   const isSectionValid = watch("petName") && watch("type") && watch("breed") !== "";
@@ -255,6 +253,7 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
     if (isLeader && isOnlyMember) {
       deletePetMutation(String(petId));
     }
+    router.push("/settings");
   };
 
   const section1 = (
@@ -378,7 +377,16 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
 
       {isDeleteModalOpen && <ImageModal type={"deletePet"} onClick={handleLeaderDelete} onClose={closeDeleteModalFunc} />}
       {isUnAuthorizedModalOpen && <ImageModal type={"unAuthorizedDeletePet"} onClick={closeUnAuthorizedModalFunc} onClose={closeUnAuthorizedModalFunc} />}
-      {isConfirmModalOpen && <ImageModal type={"edit"} onClick={closeConfirmModalFunc} onClose={closeConfirmModalFunc} />}
+      {isConfirmModalOpen && (
+        <ImageModal
+          type={"edit"}
+          onClick={() => {
+            closeConfirmModalFunc();
+            router.back();
+          }}
+          onClose={closeConfirmModalFunc}
+        />
+      )}
     </>
   );
 

--- a/app/settings/_components/EditPetRegisterForm/index.tsx
+++ b/app/settings/_components/EditPetRegisterForm/index.tsx
@@ -28,6 +28,7 @@ import { getMe } from "@/app/_api/users";
 import { UserType } from "@/app/_types/user/types";
 import ImageModal from "@/app/_components/Modal/ImageModal";
 import { getImagePath } from "@/app/_utils/getPetImagePath";
+import Loading from "@/app/_components/Loading";
 
 export interface IFormInput {
   petName: string;
@@ -406,6 +407,7 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
       <form onSubmit={handleSubmit(onSubmit)} className={styles.formContainer}>
         {section === 1 ? section1 : section2}
       </form>
+      {isPending && <Loading />}
     </>
   );
 };

--- a/app/settings/_components/EditPetRegisterForm/index.tsx
+++ b/app/settings/_components/EditPetRegisterForm/index.tsx
@@ -159,8 +159,8 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
       setSelectedGender(petInfo.gender);
       setValue("neutering", petInfo.isNeutered === "Y" ? true : false);
       setSelectedNeutering(petInfo.isNeutered === "Y" ? "true" : "false");
-      setValue("birthday", petInfo.birth === null ? null : petInfo.birth.slice(0, 10));
-      setValue("firstMeet", petInfo.firstMeetDate === null ? null : petInfo?.firstMeetDate!.slice(0, 10));
+      setValue("birthday", petInfo.birth === null ? "날짜 선택" : petInfo.birth.slice(0, 10));
+      setValue("firstMeet", petInfo.firstMeetDate === null ? "날짜 선택" : petInfo?.firstMeetDate!.slice(0, 10));
       setValue("weight", petInfo.weight);
       setValue("registeredNumber", petInfo.registeredNumber);
 

--- a/app/settings/_components/EditPetRegisterForm/index.tsx
+++ b/app/settings/_components/EditPetRegisterForm/index.tsx
@@ -121,7 +121,7 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
     setValue,
     getValues,
     watch,
-  } = useForm<IFormInput>({ mode: "onSubmit" });
+  } = useForm<IFormInput>({ mode: "onTouched" });
 
   //section1의 유효성 검사(값이 있는 경우에만 버튼클릭가능)
   const isSectionValid = watch("petName") && watch("type") && watch("breed") !== "";

--- a/app/settings/pet-info/[id]/page.tsx
+++ b/app/settings/pet-info/[id]/page.tsx
@@ -8,8 +8,6 @@ const Page = () => {
   const segments = pathname.split("/");
   const petId = Number(segments[segments.length - 1]);
 
-  console.log(petId);
-
   return (
     <div>
       <EditPetRegisterForm petId={petId} />;


### PR DESCRIPTION
## 📌 관련 이슈
- close #270 

## 💻 주요 변경 사항
- [x] pet-register에 invalidate query 추가 → 반려동물 NEW 등록시 캐러셀에 곧바로 추가됨 
- [x] 반려동물 수정하면 수정폼 자동으로 넘어가지 않고 모달 확인버튼 눌러야!!! 넘어가도록 수정
- [x] 라디오버튼 선택시 날짜 초기화되던 버그 수정
- [x] getPet으로 받아온 날짜 값이 null일 경우 '날짜 선택'이 초기값으로 보여지도록 수정

- [x] 수정폼 isPending일때 로딩스피너 보여주도록 추가 (잘 된건지는 모름....)
- [x] 사용하지 않는 콘솔로그 제거
===================================

집가서 할 일
- [ ] 깃 위키 꾸미기
- [ ] 다른 분들 로딩 처리하신 것 보고 힌트 얻어서 추가하기.... (등록폼은 mutation 사용하지 않아서 useState 추가해보았는데 로딩스피너가 폼과 함께 렌더링되어서 삭제함,,,ㅎ)
- [ ] 드롭다운 영원히 열리기만 하는 문제 한번만 더......도전하기..... ㅜㅜㅜㅜㅜㅜ 

## 📸 스크린샷

## 📣 기타 문의(선택)
-
