### PR TITLE
[#257] refactor : 건강수첩 페이지 optimistic skeleton 적용

### DIFF
--- a/app/healthlog/_components/HealthlogSkeleton/index.tsx
+++ b/app/healthlog/_components/HealthlogSkeleton/index.tsx
@@ -1,0 +1,11 @@
+import { container, skeleton, skeletonShine } from "./style.css";
+
+const Skeleton = () => (
+  <div className={container}>
+    <div className={skeleton}>
+      <div className={skeletonShine}></div>
+    </div>
+  </div>
+);
+
+export default Skeleton;

--- a/app/healthlog/_components/HealthlogSkeleton/style.css.ts
+++ b/app/healthlog/_components/HealthlogSkeleton/style.css.ts
@@ -1,0 +1,44 @@
+import { keyframes, style } from "@vanilla-extract/css";
+
+const loadingAnimation = keyframes({
+  "100%": { backgroundPosition: "-100% 0" },
+});
+
+export const container = style({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+});
+
+export const skeleton = style({
+  width: "100%",
+  maxWidth: "35rem",
+
+  margin: "2.4rem 1.6rem",
+  padding: "1rem",
+
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+
+  borderRadius: "10px",
+
+  marginBottom: "4rem",
+  "@media": {
+    "screen and (min-width: 744px)": {
+      maxWidth: "45rem",
+      height: "37rem",
+    },
+  },
+});
+
+export const skeletonShine = style({
+  willChange: "background-position",
+  width: "100%",
+  height: "100%",
+  background: "linear-gradient(120deg, #ffeee4 30%, #ffffff 38%, #ffffff 40%, #ffeee4 48%)",
+  backgroundSize: "200% 100%",
+  borderRadius: "10px",
+  backgroundPosition: "100% 0",
+  animation: `${loadingAnimation} 1s infinite`,
+});

--- a/app/healthlog/page.tsx
+++ b/app/healthlog/page.tsx
@@ -4,6 +4,8 @@ import { getLogs } from "@/app/_api/log";
 import LogWriteButton from "@/app/healthlog/_components/LogWriteButton";
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 import { cookies } from "next/headers";
+import { Suspense } from "react";
+import HealthlogSkeleton from "./_components/HealthlogSkeleton";
 import HealthlogContent from "./_components/HealthlogContent";
 import * as styles from "./page.css";
 
@@ -26,7 +28,9 @@ const Page = async () => {
     <HydrationBoundary state={dehydratedState}>
       <div className={styles.container}>
         <p className={styles.title}>건강수첩</p>
-        <HealthlogContent petId={petId} />
+        <Suspense fallback={<HealthlogSkeleton />}>
+          <HealthlogContent petId={petId} />
+        </Suspense>
         <LogWriteButton />
       </div>
     </HydrationBoundary>


### PR DESCRIPTION
## 📌 관련 이슈
- close #257

## 💻 주요 변경 사항

- [ ] 건강수첩 진입시 Slow 3G로 하고 보면 깜빡이는것처럼 보이는 현상(아래 영상) - 캘린더가 빈 상태였다가 로드됨 -> Optimistic Skeleton 해당 영역에 적용했는데 코드는 틀리지 않으나, 스켈레톤이 안보임
-> 일단 배포 사이트에서 처음에 렌더링 될때 빠르게 되긴 하는데... 이건 좀 더 알아봐야 될 것 같아요.

## 📸 스크린샷

https://github.com/ppp-team/my-pet-log/assets/133554119/82d470af-1901-4919-840f-7d5f6b4d2d98


## 📣 기타 문의(선택)
-
