### PR TITLE
Feat/friend pet page layout

### DIFF
--- a/app/_constants/pagesWithHeader.ts
+++ b/app/_constants/pagesWithHeader.ts
@@ -1,4 +1,4 @@
 export const pagesWithHeader = {
   logo: ["/home-select", "/healthlog/select", "/diary/select", "/settings/faq", "/settings/notice", "/settings/ask", "/settings", "/settings/received-invite"],
-  petGroup: ["/home", "/healthlog", "/diary/my-pet", "/settings/member", "/settings/invitation", "/settings/blocked-user", "/settings/subscriber"],
+  petGroup: ["/home", "/healthlog", "/diary/my-pet", "/diary/friend-pet", "/settings/member", "/settings/invitation", "/settings/blocked-user", "/settings/subscriber"],
 };

--- a/app/diary/(diary)/friend-pet/page.tsx
+++ b/app/diary/(diary)/friend-pet/page.tsx
@@ -1,5 +1,22 @@
+import Image from "next/image";
+import { getImagePath } from "@/app/_utils/getPetImagePath";
+import * as styles from "./style.css";
+
+const mock = {
+  name: "은행이",
+  isSubscribed: true,
+  profileImage: null,
+};
+
 const FriendPetDiaryPage = async () => {
-  return <div>친구의 일기</div>;
+  return (
+    <section className={styles.profileInfo}>
+      <Image src={getImagePath(mock.profileImage)} alt="profile image" width={45} height={45} />
+      <div className={styles.text}>
+        {mock.name} · {mock.isSubscribed ? "구독 중 🐾" : "구독하기"}
+      </div>
+    </section>
+  );
 };
 
 export default FriendPetDiaryPage;

--- a/app/diary/(diary)/friend-pet/style.css.ts
+++ b/app/diary/(diary)/friend-pet/style.css.ts
@@ -1,0 +1,14 @@
+import { style } from "@vanilla-extract/css";
+
+export const profileInfo = style({
+  margin: "2rem 2rem 0rem",
+  display: "flex",
+  justifyItems: "center",
+  alignItems: "center",
+  gap: "1.2rem",
+});
+
+export const text = style({
+  fontSize: "1.4rem",
+  fontWeight: "600",
+});


### PR DESCRIPTION
## 📌 관련 이슈
- close #298 

## 💻 주요 변경 사항
- 친구의 일기 프로필 정보 레이아웃
- 상단, 하단메뉴 보이도록 설정

## 📸 스크린샷
<img width="317" alt="스크린샷 2024-03-20 오후 9 53 38" src="https://github.com/ppp-team/my-pet-log/assets/72639353/5cf177c6-9bdb-4b6b-a13e-5c2f5137ec30">

## 📣 기타 문의(선택)
-
