### PR TITLE
[#298] feat : 친구의 일기 이미지 슬라이드 구현

### DIFF
--- a/app/diary/(diary)/friend-pet/page.tsx
+++ b/app/diary/(diary)/friend-pet/page.tsx
@@ -1,21 +1,71 @@
+"use client";
+
 import Image from "next/image";
 import { getImagePath } from "@/app/_utils/getPetImagePath";
 import * as styles from "./style.css";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/css";
+import "swiper/css/pagination";
+import { Pagination } from "swiper/modules";
+import "./swiper.css";
 
 const mock = {
   name: "은행이",
   isSubscribed: true,
   profileImage: null,
+  images: [
+    {
+      mediaId: 0,
+      path: "https://phinf.pstatic.net/contact/20220825_253/1661385964853G7XN3_JPEG/KakaoTalk_20220825_090521205.jpg?type=s160",
+    },
+    {
+      mediaId: 0,
+      path: "https://phinf.pstatic.net/contact/20220825_253/1661385964853G7XN3_JPEG/KakaoTalk_20220825_090521205.jpg?type=s160",
+    },
+    {
+      mediaId: 0,
+      path: "https://phinf.pstatic.net/contact/20220825_253/1661385964853G7XN3_JPEG/KakaoTalk_20220825_090521205.jpg?type=s160",
+    },
+    {
+      mediaId: 0,
+      path: "https://phinf.pstatic.net/contact/20220825_253/1661385964853G7XN3_JPEG/KakaoTalk_20220825_090521205.jpg?type=s160",
+    },
+    {
+      mediaId: 0,
+      path: "https://phinf.pstatic.net/contact/20220825_253/1661385964853G7XN3_JPEG/KakaoTalk_20220825_090521205.jpg?type=s160",
+    },
+    {
+      mediaId: 0,
+      path: "https://phinf.pstatic.net/contact/20220825_253/1661385964853G7XN3_JPEG/KakaoTalk_20220825_090521205.jpg?type=s160",
+    },
+  ],
 };
 
-const FriendPetDiaryPage = async () => {
+const FriendPetDiaryPage = () => {
   return (
-    <section className={styles.profileInfo}>
-      <Image src={getImagePath(mock.profileImage)} alt="profile image" width={45} height={45} />
-      <div className={styles.text}>
-        {mock.name} · {mock.isSubscribed ? "구독 중 🐾" : "구독하기"}
-      </div>
-    </section>
+    <>
+      <section className={styles.profileInfo}>
+        <Image src={getImagePath(mock.profileImage)} alt="profile image" width={45} height={45} />
+        <div className={styles.text}>
+          {mock.name} · {mock.isSubscribed ? "구독 중 🐾" : "구독하기"}
+        </div>
+      </section>
+      <Swiper
+        className="friend"
+        centeredSlides={true}
+        pagination={{
+          dynamicBullets: true,
+          dynamicMainBullets: 3,
+        }}
+        modules={[Pagination]}
+      >
+        {mock.images.map((image, idx) => (
+          <SwiperSlide key={idx}>
+            <div className={styles.image} style={{ backgroundImage: `url(${image.path})` }}></div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </>
   );
 };
 

--- a/app/diary/(diary)/friend-pet/style.css.ts
+++ b/app/diary/(diary)/friend-pet/style.css.ts
@@ -1,7 +1,7 @@
 import { style } from "@vanilla-extract/css";
 
 export const profileInfo = style({
-  margin: "2rem 2rem 0rem",
+  margin: "2rem 2rem 1rem",
   display: "flex",
   justifyItems: "center",
   alignItems: "center",
@@ -11,4 +11,12 @@ export const profileInfo = style({
 export const text = style({
   fontSize: "1.4rem",
   fontWeight: "600",
+});
+
+export const image = style({
+  width: "100%",
+  height: "35rem",
+
+  backgroundSize: "cover",
+  backgroundPosition: "center",
 });

--- a/app/diary/(diary)/friend-pet/swiper.css
+++ b/app/diary/(diary)/friend-pet/swiper.css
@@ -1,0 +1,10 @@
+.swiper.friend .swiper-pagination-bullet {
+  background-color: var(--MainOrange);
+}
+
+.swiper.friend .swiper-pagination {
+  width: 100% !important;
+  position: static;
+  transform: unset;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #298

## 💻 주요 변경 사항
- 인스타그램 참고하면서 하고있어요
- 하단 점슬라이드도 인스타랑 똑같이 함..현재 활성화된 점이 3개인 점, 현재 슬라이드를 가운데에 놓는 점 등등..
- 사진마다 가로, 세로 높이가 달라서 이걸 어떻게 화면에 출력할 지 고민을 좀 해봐야겠네요

## 📸 스크린샷
https://github.com/ppp-team/my-pet-log/assets/72639353/ff8b2389-e810-4e02-8463-31c110fe113b

## 📣 기타 문의(선택)
-
