### PR TITLE
[#302] feat : 답글(대댓글) 수정, 좋아요, 삭제 즉시 반영 & @닉네임 태그 적용

### DIFF
--- a/app/_types/diary/type.ts
+++ b/app/_types/diary/type.ts
@@ -31,8 +31,9 @@ export interface CommentType {
   commentId: number;
   content: string;
   createdAt: string;
-  likeCount: number;
   isCurrentUserLiked: boolean;
+  likeCount: number;
+  recommentCount: number;
   writer: Writer;
   taggedUsers: Tag[];
 }

--- a/app/diary/_components/DiaryDetail/Comment/index.tsx
+++ b/app/diary/_components/DiaryDetail/Comment/index.tsx
@@ -94,10 +94,10 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["reComments", commentId] });
       setReCommentValue("");
-      showToast("대댓글이 생성되었습니다.", true);
+      showToast("답글이 생성되었습니다.", true);
     },
     onError: () => {
-      showToast("대댓글 생성에 실패했습니다.", false);
+      showToast("답글 생성에 실패했습니다.", false);
     },
   });
 

--- a/app/diary/_components/DiaryDetail/Comment/index.tsx
+++ b/app/diary/_components/DiaryDetail/Comment/index.tsx
@@ -93,6 +93,7 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
       queryClient.invalidateQueries({ queryKey: ["reComments", commentId] });
       setReCommentValue("");
       showToast("답글이 생성되었습니다.", true);
+      setShowReCommentInput(false);
     },
     onError: () => {
       showToast("답글 생성에 실패했습니다.", false);
@@ -127,6 +128,11 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
   const handlePostReComment = () => {
     if (!reCommentValue.trim()) return;
     postReCommentMutation.mutate();
+  };
+
+  const handleReCommentButtonClick = (nickname: string) => {
+    setShowReCommentInput(true);
+    setReCommentValue(`@${nickname} `);
   };
 
   const toggleReCommentInput = () => setShowReCommentInput((prev) => !prev);
@@ -184,7 +190,7 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
           )}
 
           <div style={{ display: "flex", justifyContent: "flex-end" }}>
-            <button className={styles.recommentButton} onClick={toggleReCommentInput}>
+            <button className={styles.recommentButton} onClick={() => handleReCommentButtonClick(comment.writer.nickname)}>
               답글
             </button>
             <button className={`${styles.commentLikeButton} ${comment.isCurrentUserLiked ? styles.LikeIcon : ""}`} onClick={handleCommentLike}>

--- a/app/diary/_components/DiaryDetail/Comment/index.tsx
+++ b/app/diary/_components/DiaryDetail/Comment/index.tsx
@@ -40,8 +40,6 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
 
   const reComments = reCommentsData ?? [];
 
-  console.log(reComments);
-
   //댓글 삭제
   const deleteCommentMutation = useMutation({
     mutationFn: (commentId: number) => deleteComment({ commentId }),
@@ -90,7 +88,7 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
 
   // 대댓글 생성 로직
   const postReCommentMutation = useMutation({
-    mutationFn: () => postReComment({ commentId, content: reCommentValue, taggedUserIds: [] }), // 필요한 경우 taggedUserIds를 적절히 설정
+    mutationFn: () => postReComment({ commentId, content: reCommentValue, taggedUserIds: [] }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["reComments", commentId] });
       setReCommentValue("");
@@ -127,7 +125,7 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
   };
 
   const handlePostReComment = () => {
-    if (!reCommentValue.trim()) return; // 내용이 없으면 전송하지 않음
+    if (!reCommentValue.trim()) return;
     postReCommentMutation.mutate();
   };
 

--- a/app/diary/_components/DiaryDetail/ReComment/index.tsx
+++ b/app/diary/_components/DiaryDetail/ReComment/index.tsx
@@ -1,4 +1,5 @@
 import { deleteComment, postCommentLike, putComment } from "@/app/_api/diary";
+import { GetReCommentsResponse } from "@/app/_types/diary/type";
 import Modal from "@/app/_components/Modal";
 import { showToast } from "@/app/_components/Toast";
 import { useModal } from "@/app/_hooks/useModal";
@@ -37,7 +38,9 @@ const ReComment = ({ reply, ancestorId }: ReCommentProps) => {
   const deleteReCommentMutation = useMutation({
     mutationFn: () => deleteComment({ commentId: reply.commentId }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["reComments", { ancestorId }] });
+      queryClient.setQueryData<GetReCommentsResponse>(["reComments", ancestorId], (oldData) => {
+        return oldData!.filter((comment) => comment.commentId !== reply.commentId);
+      });
       showToast("답글을 삭제했습니다.", true);
       closeModalFunc();
     },
@@ -49,7 +52,10 @@ const ReComment = ({ reply, ancestorId }: ReCommentProps) => {
   const putReCommentMutation = useMutation({
     mutationFn: () => putComment({ commentId: reply.commentId, content: newCommentValue }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["reComments", { ancestorId }] });
+      queryClient.setQueryData<GetReCommentsResponse>(["reComments", ancestorId], (oldData) => {
+        const newData = oldData!.map((comment) => (comment.commentId === reply.commentId ? { ...comment, content: newCommentValue } : comment));
+        return newData;
+      });
       showToast("답글을 수정했습니다.", true);
       setIsEditing(false);
     },
@@ -60,13 +66,40 @@ const ReComment = ({ reply, ancestorId }: ReCommentProps) => {
 
   const postReCommentLikeMutation = useMutation({
     mutationFn: () => postCommentLike({ commentId: reply.commentId }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["reComments", { ancestorId }] });
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: ["reComments", ancestorId],
+      });
+      const previousReComments = queryClient.getQueryData<GetReCommentsResponse>(["reComments", ancestorId]);
+      queryClient.setQueryData<GetReCommentsResponse>(["reComments", ancestorId.toString()], (oldReComments) => {
+        return (
+          oldReComments?.map((reComment) =>
+            reComment.commentId === reply.commentId
+              ? { ...reComment, likeCount: reComment.isCurrentUserLiked ? reComment.likeCount - 1 : reComment.likeCount + 1, isCurrentUserLiked: !reComment.isCurrentUserLiked }
+              : reComment,
+          ) ?? []
+        );
+      });
+
+      return { previousReComments: previousReComments ?? [] };
     },
-    onError: () => {
-      showToast("답글 좋아요 실패", false);
+    onError: (err, variables, context) => {
+      if (context?.previousReComments) {
+        queryClient.setQueryData(["reComments", ancestorId.toString()], context.previousReComments);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["reComments", ancestorId],
+      });
     },
   });
+
+  // ...
+
+  const handleLikeClick = () => {
+    postReCommentLikeMutation.mutate();
+  };
 
   const handleEditClick = () => {
     setIsEditing(true);
@@ -129,7 +162,7 @@ const ReComment = ({ reply, ancestorId }: ReCommentProps) => {
         )}
 
         <div style={{ display: "flex", justifyContent: "flex-end" }}>
-          <button className={`${styles.commentLikeButton} ${reply.isCurrentUserLiked ? styles.LikeIcon : ""}`} onClick={() => postReCommentLikeMutation.mutate()}>
+          <button className={`${styles.commentLikeButton} ${reply.isCurrentUserLiked ? styles.LikeIcon : ""}`} onClick={handleLikeClick}>
             <LikeIcon color={reply.isCurrentUserLiked ? "var(--MainOrange)" : "var(--Gray81)"} />
             {reply.likeCount}
           </button>

--- a/app/diary/_components/DiaryDetail/ReComment/index.tsx
+++ b/app/diary/_components/DiaryDetail/ReComment/index.tsx
@@ -38,11 +38,11 @@ const ReComment = ({ reply, ancestorId }: ReCommentProps) => {
     mutationFn: () => deleteComment({ commentId: reply.commentId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["reComments", { ancestorId }] });
-      showToast("대댓글을 삭제했습니다.", true);
+      showToast("답글을 삭제했습니다.", true);
       closeModalFunc();
     },
     onError: () => {
-      showToast("대댓글 삭제에 실패했습니다.", false);
+      showToast("답글 삭제에 실패했습니다.", false);
     },
   });
 
@@ -50,11 +50,11 @@ const ReComment = ({ reply, ancestorId }: ReCommentProps) => {
     mutationFn: () => putComment({ commentId: reply.commentId, content: newCommentValue }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["reComments", { ancestorId }] });
-      showToast("대댓글을 수정했습니다.", true);
+      showToast("답글을 수정했습니다.", true);
       setIsEditing(false);
     },
     onError: () => {
-      showToast("대댓글 수정에 실패했습니다.", false);
+      showToast("답글 수정에 실패했습니다.", false);
     },
   });
 
@@ -64,7 +64,7 @@ const ReComment = ({ reply, ancestorId }: ReCommentProps) => {
       queryClient.invalidateQueries({ queryKey: ["reComments", { ancestorId }] });
     },
     onError: () => {
-      showToast("대댓글 좋아요 실패", false);
+      showToast("답글 좋아요 실패", false);
     },
   });
 
@@ -135,7 +135,7 @@ const ReComment = ({ reply, ancestorId }: ReCommentProps) => {
           </button>
         </div>
       </div>
-      {isModalOpen && <Modal text="정말 대댓글을 삭제하시겠습니까?" buttonText="삭제" onClick={() => deleteReCommentMutation.mutate()} onClose={closeModalFunc} />}
+      {isModalOpen && <Modal text="정말 답글을 삭제하시겠습니까?" buttonText="삭제" onClick={() => deleteReCommentMutation.mutate()} onClose={closeModalFunc} />}
     </div>
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈
- close #302 

## 💻 주요 변경 사항
- [x] 답글(대댓글) 수정, 좋아요, 삭제 즉시 화면에 반영되도록 수정
- [x] 답글 작성시, 댓글의 작성자 @닉네임 반영되도록 구현
(다만, textarea 내부에 삽입되게 하는 방식이라 닉네임 태그 링크의 개념이 아니라 단순 텍스트로 적용이 되게 구현) 

## 📸 스크린샷


https://github.com/ppp-team/my-pet-log/assets/133554119/457b1420-181d-4806-bb9f-dbda4d965649



## 📣 기타 문의(선택)
-
