### PR TITLE
[#349] QA fix : 일기 검색 api 재연동 & 펫 이름 10자 초과 중복검사x

### DIFF
--- a/app/_api/diary/index.ts
+++ b/app/_api/diary/index.ts
@@ -127,6 +127,17 @@ export const getSearchDiary = async ({ page, size, keyword }: getSearchDiaryRequ
   }
 };
 
+export const getSearchTerms = async () => {
+  try {
+    const petId = cookies().get("petId")?.value;
+    const res = await instance.get(`pets/${petId}/diaries/search/terms`);
+
+    return res.data;
+  } catch (error: any) {
+    console.error(error.response.data);
+  }
+};
+
 export const postDiaryLike = async ({ diaryId }: { diaryId: number }) => {
   const petId = cookies().get("petId")?.value;
   await instance.post(`pets/${petId}/diaries/${diaryId}/like`);

--- a/app/_components/PetRegister/index.tsx
+++ b/app/_components/PetRegister/index.tsx
@@ -208,7 +208,12 @@ const PetRegister = () => {
           })}
           placeholder={PET_PLACEHOLDER.name}
         />
-        <button disabled={!getValues("petName")} className={styles.checkPetNameButton} type="button" onClick={() => checkPetNameMutation.mutate(getValues("petName"))}>
+        <button
+          disabled={!getValues("petName") || getValues("petName").length > 10}
+          className={styles.checkPetNameButton}
+          type="button"
+          onClick={() => checkPetNameMutation.mutate(getValues("petName"))}
+        >
           중복확인
         </button>
       </div>

--- a/app/diary/search/page.tsx
+++ b/app/diary/search/page.tsx
@@ -58,6 +58,7 @@ const Search = () => {
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => (lastPage?.last ? undefined : lastPageParam + 1),
     enabled: !!keyword,
+    staleTime: 0,
   });
   const { targetRef, setTargetActive } = useInfiniteScroll({ callbackFunc: fetchNextPage });
 

--- a/app/settings/_components/EditPetRegisterForm/index.tsx
+++ b/app/settings/_components/EditPetRegisterForm/index.tsx
@@ -262,7 +262,7 @@ const EditPetRegisterForm = ({ petId }: { petId: number }) => {
           placeholder={PET_PLACEHOLDER.name}
         />
         <button
-          disabled={!getValues("petName") || isPetNameConfirm === null}
+          disabled={!getValues("petName") || isPetNameConfirm === null || getValues("petName").length > 10}
           className={styles.checkPetNameButton}
           type="button"
           onClick={() => checkPetNameMutation.mutate(getValues("petName"))}


### PR DESCRIPTION
## 📌 관련 이슈
- close #349 

## 💻 주요 변경 사항
- [x] 일기 검색 api 재연동
이전 일기에 대해서는 검색 안 되는 이슈가 있는데 새로운 일기는 잘 되는걸로 봐서 db에서 뭐가 지워졌거나 했던 게 영향이 있는 거 같아요.
- [x] 펫 이름 10자 초과 중복검사x
<img width="593" alt="스크린샷 2024-04-26 오후 3 22 30" src="https://github.com/ppp-team/my-pet-log/assets/144668146/42997658-a400-4ced-b0ce-6228b18f3253">
<img width="594" alt="스크린샷 2024-04-26 오후 3 22 53" src="https://github.com/ppp-team/my-pet-log/assets/144668146/d925194c-933a-405c-b760-1728287a86a8">

## 📸 스크린샷
<img width="368" alt="스크린샷 2024-04-26 오후 3 23 12" src="https://github.com/ppp-team/my-pet-log/assets/144668146/b58336d3-8029-4002-8a8e-55a501c78481">

<img width="359" alt="스크린샷 2024-04-26 오후 3 23 51" src="https://github.com/ppp-team/my-pet-log/assets/144668146/e2db16f1-aa0b-479a-9041-5ec019c75261">

## 📣 기타 문의(선택)
-
