### PR TITLE
[#351] Refactor : 경로에 알맞게 카드캐러셀 연필모양 보이게 하기 

### DIFF
--- a/app/settings/_components/InviteModal/InviteCode/index.tsx
+++ b/app/settings/_components/InviteModal/InviteCode/index.tsx
@@ -51,7 +51,7 @@ const InviteCode = ({ petId }: { petId: number }) => {
     <>
       <h3 className={styles.title}>마이펫 초대 코드</h3>
       <section className={styles.codeContainer}>
-        {petInfo && <MyPetInfo petInfo={petInfo} />}
+        {petInfo && <MyPetInfo petInfo={petInfo} isSettingsPage={false} />}
         <div className={styles.copyContainer}>
           <span className={styles.code}>{code}</span>
           <button className={styles.copyIcon} onClick={handleCopyClick}>

--- a/app/settings/_components/MyPetInfo/index.tsx
+++ b/app/settings/_components/MyPetInfo/index.tsx
@@ -16,9 +16,10 @@ interface StyleProps {
 
 interface MyPetProps extends StyleProps {
   petInfo: PetType;
+  isSettingsPage: boolean;
 }
 
-const MyPetInfo = ({ petInfo, styles }: MyPetProps) => {
+const MyPetInfo = ({ petInfo, styles, isSettingsPage }: MyPetProps) => {
   // 프롭 안넘겨줄 시 기본값들
   const { profileBorderColor = "var(--MainOrange)", nameTextColor = "var(--Black)", breedTextColor = "var(--Gray81)" } = styles || {};
   const gender = petInfo.gender === "MALE" ? "남아" : "여아";
@@ -47,9 +48,11 @@ const MyPetInfo = ({ petInfo, styles }: MyPetProps) => {
           {age}
         </span>
       </div>
-      <Link href={`/settings/pet-info/${petInfo.petId}`} className={iconWrapper}>
-        <Image className={icon} src={EditIcon} alt="Edit icon" width={20} height={20} />
-      </Link>
+      {isSettingsPage && (
+        <Link href={`/settings/pet-info/${petInfo.petId}`} className={iconWrapper}>
+          <Image className={icon} src={EditIcon} alt="Edit icon" width={20} height={20} />
+        </Link>
+      )}
     </div>
   );
 };

--- a/app/settings/_components/MypetCarousel/index.tsx
+++ b/app/settings/_components/MypetCarousel/index.tsx
@@ -12,13 +12,15 @@ import AddIcon from "@/public/icons/add.svg?url";
 import Link from "next/link";
 import { PetsType } from "@/app/_types/pets/types";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { editPetRep, getPets } from "@/app/_api/pets";
 import Skeleton from "./Skeleton";
 
 const MyPetCarousel = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
+  const pathname = usePathname();
+  const isSettingsPage = pathname.startsWith("/settings");
 
   const {
     data: pets,
@@ -69,7 +71,7 @@ const MyPetCarousel = () => {
             {pets?.data.map((petInfo) => (
               <SwiperSlide className="mypet" key={petInfo.petId}>
                 <div className={styles.container}>
-                  <div className={styles.petInfoWrapper}>{petInfo && <MyPetInfo petInfo={petInfo} styles={myPetInfoStyles} />}</div>
+                  <div className={styles.petInfoWrapper}>{petInfo && <MyPetInfo petInfo={petInfo} styles={myPetInfoStyles} isSettingsPage={isSettingsPage} />}</div>
                   <button
                     className={styles.petMateButton}
                     onClick={() => {
@@ -78,8 +80,6 @@ const MyPetCarousel = () => {
                   >
                     펫메이트 관리
                   </button>
-
-                  {/* 구독자 관리의 onClick이벤트 수정 필요  */}
                   <button
                     onClick={() => {
                       editPetSubscriptionMutate(String(petInfo.petId));


### PR DESCRIPTION
## 📌 관련 이슈
- close #351

## 💻 주요 변경 사항
- 컴포넌트 분리하지 않고 usePathname 사용해서 초대모달에는 연필아이콘 안보이고 셋팅캐러셀에는 보이도록 했습니다!!

## 📸 스크린샷
![image](https://github.com/ppp-team/my-pet-log/assets/144667455/40a724b2-3753-4b62-9830-5b2142bad97b)
![image](https://github.com/ppp-team/my-pet-log/assets/144667455/0a2b8779-3321-4209-8839-5f6bbea6108d)


## 📣 기타 문의(선택)
-
