### PR TITLE
[#328] refactor : 대댓글 태그 로직 수정

### DIFF
--- a/app/_api/diary/index.ts
+++ b/app/_api/diary/index.ts
@@ -91,8 +91,8 @@ export const postComment = async ({ petId, diaryId, content }: PostCommentReques
   return res.data;
 };
 
-export const postReComment = async ({ petId, commentId, content, taggedUsers }: PostReCommentRequest): Promise<GetReCommentsResponse> => {
-  const res = await instance.post(`pets/${petId}/diaries/comments/${commentId}/recomment`, { content, taggedUsers });
+export const postReComment = async ({ petId, commentId, content }: PostReCommentRequest): Promise<GetReCommentsResponse> => {
+  const res = await instance.post(`pets/${petId}/diaries/comments/${commentId}/recomment`, { content });
   return res.data;
 };
 

--- a/app/_types/diary/type.ts
+++ b/app/_types/diary/type.ts
@@ -116,6 +116,12 @@ export interface CommentType {
   likeCount: number;
   writer: Writer;
   taggedUsers: Tag[];
+  receiver?: {
+    id: string;
+    nickname: string;
+    profilePath: string;
+    isCurrentUser: boolean;
+  };
 }
 
 export interface GetCommentsRequest extends GetDiaryListRequest {

--- a/app/diary/_components/DiaryDetail/Comment/index.tsx
+++ b/app/diary/_components/DiaryDetail/Comment/index.tsx
@@ -31,7 +31,6 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
   const [reCommentValue, setReCommentValue] = useState("");
   const [showReCommentInput, setShowReCommentInput] = useState(false);
   const [taggedNicknames, setTaggedNicknames] = useState<string[]>([]);
-  const [taggedUserId, setTaggedUserId] = useState<string | null>(null);
   const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const queryClient = useQueryClient();
@@ -93,12 +92,10 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
         petId,
         commentId,
         content: reCommentValue,
-        taggedUsers: taggedUserId ? [taggedUserId] : [],
       }),
     onSuccess: (newReComment) => {
       const currentReComments = queryClient.getQueryData<GetReCommentsResponse[]>(["reComments", diaryId, commentId]) ?? [];
       queryClient.setQueryData(["reComments", diaryId, commentId], [newReComment, ...currentReComments]);
-      console.log(taggedUserId);
       showToast("답글이 생성되었습니다.", true);
       setReCommentValue("");
       setShowReCommentInput(false);
@@ -134,7 +131,6 @@ const Comment = ({ comment, diaryId, pageNum, contentNum, petId, commentId }: Co
   const handleReCommentButtonClick = () => {
     setShowReCommentInput(true);
     setTaggedNicknames([comment.writer.nickname]);
-    setTaggedUserId(comment.writer.id);
     textAreaRef.current?.focus();
   };
 

--- a/app/diary/_components/DiaryDetail/ReComment/index.tsx
+++ b/app/diary/_components/DiaryDetail/ReComment/index.tsx
@@ -27,6 +27,12 @@ interface ReCommentProps {
       profilePath: string;
       isCurrentUser: boolean;
     };
+    receiver?: {
+      id: string;
+      nickname: string;
+      profilePath: string;
+      isCurrentUser: boolean;
+    };
   };
   ancestorId: number;
 }
@@ -61,7 +67,6 @@ const ReComment = ({ petId, diaryId, reply, ancestorId }: ReCommentProps) => {
         petId,
         commentId: reply.commentId,
         content: newCommentValue,
-        taggedUsers: [reply.writer.id],
       }),
     onSuccess: () => {
       const currentReComments = queryClient.getQueryData<GetReCommentsResponse>(["reComments", diaryId, ancestorId]);
@@ -93,7 +98,7 @@ const ReComment = ({ petId, diaryId, reply, ancestorId }: ReCommentProps) => {
     },
     onSettled: () => {
       queryClient.invalidateQueries({
-        queryKey: ["reComments", diaryId, reply.commentId],
+        queryKey: ["reComments", diaryId],
       });
     },
   });
@@ -159,7 +164,10 @@ const ReComment = ({ petId, diaryId, reply, ancestorId }: ReCommentProps) => {
             </button>
           </form>
         ) : (
-          <pre className={styles.commentContent}>{reply.content}</pre>
+          <div>
+            <span className={styles.tag}>@{reply.receiver?.nickname}</span>
+            <span className={styles.commentContent}>{reply.content}</span>
+          </div>
         )}
 
         <div style={{ display: "flex", justifyContent: "flex-end" }}>

--- a/app/diary/_components/DiaryDetail/ReComment/style.css.ts
+++ b/app/diary/_components/DiaryDetail/ReComment/style.css.ts
@@ -93,6 +93,14 @@ export const commentLikeButton = style({
   fontSize: "1.4rem",
 });
 
+export const tag = style({
+  marginRight: "1rem",
+
+  fontSize: "1.4rem",
+  fontWeight: "bold",
+  color: "var(--MainOrange)",
+});
+
 export const kebabList = style({
   padding: "0.6rem 2.5rem",
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## 💻 주요 변경 사항
- [x] 원선님과 논의해서 taggedUsers 관련 데이터 핸들링 필요 없는 부분 삭제 (유저 태그는 taggedUsers 아닌 대댓글 receiver 데이터로 적용하면 되고, 별도로 taggedUsers로 넣을 필요 없음)

## 📸 스크린샷
![localhost_3001_diary_detail_191(iPhone 12 Pro)](https://github.com/ppp-team/my-pet-log/assets/133554119/16e86c38-768e-40bd-bc01-e872af684679)


## 📣 기타 문의(선택)
-
