### PR TITLE
[#354] feat : 임시저장 구현

### DIFF
--- a/app/_api/diary/index.ts
+++ b/app/_api/diary/index.ts
@@ -4,19 +4,19 @@ import instance from "@/app/_api/axios";
 import {
   CommentType,
   GetCommentsRequest,
-  GetReCommentsRequest,
-  GetReCommentsResponse,
   GetCommentsResponse,
   GetDiaryListRequest,
   GetDiaryListResponse,
   GetDiaryResponse,
-  PostCommentRequest,
-  PostReCommentRequest,
-  PostDiaryVideoResponse,
-  PutCommentRequest,
-  getSearchDiaryRequest,
-  getFeedRequest,
   GetLikeListResponse,
+  GetReCommentsRequest,
+  GetReCommentsResponse,
+  PostCommentRequest,
+  PostDiaryVideoResponse,
+  PostReCommentRequest,
+  PutCommentRequest,
+  getFeedRequest,
+  getSearchDiaryRequest,
 } from "@/app/_types/diary/type";
 import { cookies } from "next/headers";
 
@@ -129,7 +129,6 @@ export const getSearchTerms = async () => {
   try {
     const petId = cookies().get("petId")?.value;
     const res = await instance.get(`pets/${petId}/diaries/search/terms`);
-
     return res.data;
   } catch (error: any) {
     console.error(error.response.data);
@@ -164,7 +163,6 @@ export const getDiaryDraftCheck = async () => {
   try {
     const petId = cookies().get("petId")?.value;
     const res = await instance.get(`pets/${petId}/diaries/drafts/check`);
-
     return res.data;
   } catch (error: any) {
     console.error(error.response.data);
@@ -184,7 +182,6 @@ export const getDiaryDraft = async () => {
   try {
     const petId = cookies().get("petId")?.value;
     const res = await instance.get(`pets/${petId}/diaries/drafts`);
-
     return res.data;
   } catch (error: any) {
     console.error(error.response.data);
@@ -195,7 +192,6 @@ export const postDiaryDraft = async ({ formData }: { formData: FormData }) => {
   const petId = cookies().get("petId")?.value;
   try {
     const res = await instance.post(`/pets/${petId}/diaries/drafts`, formData, { headers: { "Content-Type": "multipart/form-data" } });
-
     return res.data;
   } catch (error: any) {
     throw Error("일기 임시저장 실패");

--- a/app/_api/diary/index.ts
+++ b/app/_api/diary/index.ts
@@ -159,3 +159,46 @@ export const postDiaryVideo = async ({ formData }: { formData: FormData }): Prom
   const res = await instance.post(`/videos?domain=DIARY`, formData, { headers: { "Content-Type": "multipart/form-data" } });
   return res.data;
 };
+
+export const getDiaryDraftCheck = async () => {
+  try {
+    const petId = cookies().get("petId")?.value;
+    const res = await instance.get(`pets/${petId}/diaries/drafts/check`);
+
+    return res.data;
+  } catch (error: any) {
+    console.error(error.response.data);
+  }
+};
+
+export const deleteDiaryDraft = async () => {
+  try {
+    const petId = cookies().get("petId")?.value;
+    await instance.delete(`pets/${petId}/diaries/drafts`);
+  } catch (error: any) {
+    console.error(error.response.data);
+  }
+};
+
+export const getDiaryDraft = async () => {
+  try {
+    const petId = cookies().get("petId")?.value;
+    const res = await instance.get(`pets/${petId}/diaries/drafts`);
+
+    if (res.status === 200) await deleteDiaryDraft(); //임시저장 성공적으로 불러왔다면 삭제
+    return res.data;
+  } catch (error: any) {
+    console.error(error.response.data);
+  }
+};
+
+export const postDiaryDraft = async ({ formData }: { formData: FormData }) => {
+  const petId = cookies().get("petId")?.value;
+  try {
+    const res = await instance.post(`/pets/${petId}/diaries/drafts`, formData, { headers: { "Content-Type": "multipart/form-data" } });
+
+    return res.data;
+  } catch (error: any) {
+    throw Error("일기 임시저장 실패");
+  }
+};

--- a/app/_api/diary/index.ts
+++ b/app/_api/diary/index.ts
@@ -185,7 +185,6 @@ export const getDiaryDraft = async () => {
     const petId = cookies().get("petId")?.value;
     const res = await instance.get(`pets/${petId}/diaries/drafts`);
 
-    if (res.status === 200) await deleteDiaryDraft(); //임시저장 성공적으로 불러왔다면 삭제
     return res.data;
   } catch (error: any) {
     console.error(error.response.data);

--- a/app/_api/users/index.ts
+++ b/app/_api/users/index.ts
@@ -24,7 +24,7 @@ export const postCheckNickname = async (nickname: string) => {
       return true;
     }
   } catch (error: any) {
-    console.log(error.response);
+    console.error(error.response);
     if (error.response?.status === 409) {
       throw new Error("이미 사용 중인 닉네임입니다.");
     }

--- a/app/_states/atom.ts
+++ b/app/_states/atom.ts
@@ -15,3 +15,9 @@ interface CommentCounts {
 }
 
 export const commentCountAtom = atom<CommentCounts>({});
+
+export const loadDiaryDraftAtom = atom(false);
+
+export const saveDiaryDraftAtom = atom(false);
+
+export const diaryDataAtom = atom<{ title: string | null; content: string | null }>({ title: null, content: null });

--- a/app/_states/atom.ts
+++ b/app/_states/atom.ts
@@ -6,7 +6,9 @@ export const diaryImagesAtom = atom<ImagesType[]>([]);
 export const deletedVideoIdsAtom = atom<number[]>([]);
 
 export const userAccessTokenAtom = atom(null);
+
 export const userRefreshTokenAtom = atom(null);
+
 export const isLoggedInAtom = atom(false);
 interface CommentCounts {
   [diaryId: number]: number;

--- a/app/_types/diary/type.ts
+++ b/app/_types/diary/type.ts
@@ -17,6 +17,19 @@ export interface DiaryMediaType {
   path: string;
 }
 
+export interface DiaryDraftMediaType {
+  path: string;
+}
+
+export interface GetDiaryDraftResponse {
+  title: string;
+  content: string;
+  date: string;
+  isPublic: boolean;
+  images: DiaryDraftMediaType[];
+  videos: DiaryDraftMediaType[];
+}
+
 // 일기(Diary) 관련 인터페이스
 export interface Diary {
   diaryId: number;

--- a/app/diary/_components/DiaryDetail/index.tsx
+++ b/app/diary/_components/DiaryDetail/index.tsx
@@ -41,7 +41,7 @@ const DiaryDetail = ({ petId, diaryId }: { petId: number; diaryId: number }) => 
     mutationFn: () => deleteDiary({ diaryId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["diaries", petId] });
-      router.push("/diary");
+      router.push("/diary/my-pet");
     },
     onError: () => {
       showToast("일기 삭제에 실패했습니다.", false);

--- a/app/diary/_components/DiaryDraftModal/DiaryLoadModal.tsx
+++ b/app/diary/_components/DiaryDraftModal/DiaryLoadModal.tsx
@@ -1,14 +1,19 @@
 "use client";
-import { deleteDiaryDraft } from "@/app/_api/diary";
 import * as styles from "@/app/_components/Modal/style.css";
-import ModalContainer from "@/app/_components/ModalContainer";
 import { loadDiaryDraftAtom } from "@/app/_states/atom";
 import CloseIcon from "@/public/icons/close.svg?url";
 import { useAtom } from "jotai";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useState } from "react";
 import { text, title } from "./style.css";
 
+const ModalContainer = dynamic(
+  () => {
+    return import("@/app/_components/ModalContainer");
+  },
+  { ssr: false },
+);
 const DiaryLoadModal = () => {
   const [isOpen, setIsOpen] = useState(true);
   const [, setLoadDiaryDraft] = useAtom(loadDiaryDraftAtom);
@@ -26,7 +31,6 @@ const DiaryLoadModal = () => {
                 height={24}
                 onClick={() => {
                   setIsOpen(false);
-                  deleteDiaryDraft();
                 }}
               />
             </div>
@@ -45,7 +49,6 @@ const DiaryLoadModal = () => {
               className={styles.button}
               onClick={() => {
                 setIsOpen(false);
-                deleteDiaryDraft();
               }}
             >
               새로 작성

--- a/app/diary/_components/DiaryDraftModal/DiaryLoadModal.tsx
+++ b/app/diary/_components/DiaryDraftModal/DiaryLoadModal.tsx
@@ -18,7 +18,17 @@ const DiaryLoadModal = () => {
         <ModalContainer>
           <section className={styles.container} style={{ height: "100%", gap: "2rem" }}>
             <div className={styles.iconWrapper}>
-              <Image className={styles.closebutton} src={CloseIcon} alt="close icon" width={24} height={24} onClick={() => setIsOpen(false)} />
+              <Image
+                className={styles.closebutton}
+                src={CloseIcon}
+                alt="close icon"
+                width={24}
+                height={24}
+                onClick={() => {
+                  setIsOpen(false);
+                  deleteDiaryDraft();
+                }}
+              />
             </div>
             <div className={title}>임시저장 불러오기</div>
             <p className={text}>임시저장한 글이 있습니다.</p>

--- a/app/diary/_components/DiaryDraftModal/DiaryLoadModal.tsx
+++ b/app/diary/_components/DiaryDraftModal/DiaryLoadModal.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { deleteDiaryDraft } from "@/app/_api/diary";
+import * as styles from "@/app/_components/Modal/style.css";
+import ModalContainer from "@/app/_components/ModalContainer";
+import { loadDiaryDraftAtom } from "@/app/_states/atom";
+import CloseIcon from "@/public/icons/close.svg?url";
+import { useAtom } from "jotai";
+import Image from "next/image";
+import { useState } from "react";
+import { text, title } from "./style.css";
+
+const DiaryLoadModal = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [, setLoadDiaryDraft] = useAtom(loadDiaryDraftAtom);
+  return (
+    <>
+      {isOpen && (
+        <ModalContainer>
+          <section className={styles.container} style={{ height: "100%", gap: "2rem" }}>
+            <div className={styles.iconWrapper}>
+              <Image className={styles.closebutton} src={CloseIcon} alt="close icon" width={24} height={24} onClick={() => setIsOpen(false)} />
+            </div>
+            <div className={title}>임시저장 불러오기</div>
+            <p className={text}>임시저장한 글이 있습니다.</p>
+            <button
+              className={styles.button}
+              onClick={() => {
+                setLoadDiaryDraft(true);
+                setIsOpen(false);
+              }}
+            >
+              이이서 작성
+            </button>
+            <button
+              className={styles.button}
+              onClick={() => {
+                setIsOpen(false);
+                deleteDiaryDraft();
+              }}
+            >
+              새로 작성
+            </button>
+          </section>
+        </ModalContainer>
+      )}
+    </>
+  );
+};
+export default DiaryLoadModal;

--- a/app/diary/_components/DiaryDraftModal/DiarySaveModal.tsx
+++ b/app/diary/_components/DiaryDraftModal/DiarySaveModal.tsx
@@ -38,3 +38,5 @@ const DiarySaveModal = ({ closeModalFunc }: { closeModalFunc: () => void }) => {
     </>
   );
 };
+
+export default DiarySaveModal;

--- a/app/diary/_components/DiaryDraftModal/DiarySaveModal.tsx
+++ b/app/diary/_components/DiaryDraftModal/DiarySaveModal.tsx
@@ -16,7 +16,16 @@ const DiarySaveModal = ({ closeModalFunc }: { closeModalFunc: () => void }) => {
       <ModalContainer>
         <section className={styles.container} style={{ height: "100%", gap: "2rem" }}>
           <div className={styles.iconWrapper}>
-            <Image className={styles.closebutton} src={CloseIcon} alt="close icon" width={24} height={24} onClick={closeModalFunc} />
+            <Image
+              className={styles.closebutton}
+              src={CloseIcon}
+              alt="close icon"
+              width={24}
+              height={24}
+              onClick={async () => {
+                closeModalFunc();
+              }}
+            />
           </div>
           <div className={title}>작성하기를 나가시겠습니까?</div>
           <p className={text}>

--- a/app/diary/_components/DiaryDraftModal/DiarySaveModal.tsx
+++ b/app/diary/_components/DiaryDraftModal/DiarySaveModal.tsx
@@ -1,0 +1,40 @@
+"use client";
+import * as styles from "@/app/_components/Modal/style.css";
+import ModalContainer from "@/app/_components/ModalContainer";
+import { saveDiaryDraftAtom } from "@/app/_states/atom";
+import CloseIcon from "@/public/icons/close.svg?url";
+import { useAtom } from "jotai";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { text, title } from "./style.css";
+
+const DiarySaveModal = ({ closeModalFunc }: { closeModalFunc: () => void }) => {
+  const router = useRouter();
+  const [, setSaveDiaryDraft] = useAtom(saveDiaryDraftAtom);
+  return (
+    <>
+      <ModalContainer>
+        <section className={styles.container} style={{ height: "100%", gap: "2rem" }}>
+          <div className={styles.iconWrapper}>
+            <Image className={styles.closebutton} src={CloseIcon} alt="close icon" width={24} height={24} onClick={closeModalFunc} />
+          </div>
+          <div className={title}>작성하기를 나가시겠습니까?</div>
+          <p className={text}>
+            임시저장을 하면
+            <br />
+            다음에 이어서 작성할 수 있습니다.
+          </p>
+          <button className={styles.button} onClick={() => setSaveDiaryDraft(true)}>
+            임시저장
+          </button>
+          <button className={styles.button} onClick={closeModalFunc}>
+            계속 작성
+          </button>
+          <button className={styles.button} onClick={() => router.back()}>
+            나가기
+          </button>
+        </section>
+      </ModalContainer>
+    </>
+  );
+};

--- a/app/diary/_components/DiaryDraftModal/style.css.ts
+++ b/app/diary/_components/DiaryDraftModal/style.css.ts
@@ -1,0 +1,18 @@
+import { style } from "@vanilla-extract/css";
+
+export const title = style({
+  color: "var(--Black)",
+  textAlign: "center",
+  fontSize: "2rem",
+  fontStyle: "normal",
+  fontWeight: 600,
+  lineHeight: "normal",
+});
+export const text = style({
+  color: "var(--Gray81)",
+  fontSize: "1.6rem",
+  textAlign: "center",
+  fontStyle: "normal",
+  fontWeight: 400,
+  lineHeight: "normal",
+});

--- a/app/diary/_components/Form/CreateForm/index.tsx
+++ b/app/diary/_components/Form/CreateForm/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getDiaryDraft, postDiary, postDiaryDraft } from "@/app/_api/diary";
+import { deleteDiaryDraft, getDiaryDraft, postDiary, postDiaryDraft } from "@/app/_api/diary";
 import Loading from "@/app/_components/Loading";
 import { showToast } from "@/app/_components/Toast";
 import { diaryDataAtom, diaryImagesAtom, loadDiaryDraftAtom, saveDiaryDraftAtom } from "@/app/_states/atom";
@@ -92,6 +92,7 @@ const CreateForm = ({ petId }: { petId: number }) => {
         setOldImages([...diary.images]);
         setOldVideo([...diary.videos]);
         setValue("isPublic", diary.isPublic ? "PUBLIC" : null);
+        deleteDiaryDraft();
       }
       setLoadDiaryDraft(false); //초기화
     };

--- a/app/diary/_components/Form/CreateForm/index.tsx
+++ b/app/diary/_components/Form/CreateForm/index.tsx
@@ -1,21 +1,23 @@
 "use client";
 
-import { postDiary } from "@/app/_api/diary";
+import { getDiaryDraft, postDiary, postDiaryDraft } from "@/app/_api/diary";
 import Loading from "@/app/_components/Loading";
 import { showToast } from "@/app/_components/Toast";
-import { diaryImagesAtom } from "@/app/_states/atom";
+import { diaryDataAtom, diaryImagesAtom, loadDiaryDraftAtom, saveDiaryDraftAtom } from "@/app/_states/atom";
+import { DiaryDraftMediaType, DiaryMediaType, GetDiaryDraftResponse } from "@/app/_types/diary/type";
 import { getPrettyToday } from "@/app/_utils/getPrettyToday";
 import { FormInput } from "@/app/diary/_components/Form/EditForm";
 import DateInput from "@/app/diary/_components/Input/DateInput";
 import { ContentInput, TitleInput } from "@/app/diary/_components/Input/FormInput";
 import ImageInput from "@/app/diary/_components/Input/ImageInput";
+import PublicPrivateToggle from "@/app/diary/_components/Input/PublicPrivateToggle";
 import VideoInput from "@/app/diary/_components/Input/VideoInput";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import * as styles from "./style.css";
-import PublicPrivateToggle from "@/app/diary/_components/Input/PublicPrivateToggle";
 
 interface Diary {
   title: string;
@@ -27,6 +29,74 @@ interface Diary {
 
 const CreateForm = ({ petId }: { petId: number }) => {
   const queryClient = useQueryClient();
+  const [oldImages, setOldImages] = useState<DiaryMediaType[] | DiaryDraftMediaType[]>([]);
+  const [oldVideo, setOldVideo] = useState<DiaryMediaType[] | DiaryDraftMediaType[]>([]);
+  const [loadDiaryDraft, setLoadDiaryDraft] = useAtom(loadDiaryDraftAtom);
+  const [saveDiaryDraft, setSaveDiaryDraft] = useAtom(saveDiaryDraftAtom);
+  const [, setDiaryData] = useAtom(diaryDataAtom);
+
+  //임시저장하기
+  const { mutate: postDiaryDraftMutation, isPending: isDiarydDraftPending } = useMutation({
+    mutationFn: (formData: FormData) => postDiaryDraft({ formData }),
+    onSuccess: () => {
+      setDiaryImages([]);
+      router.back();
+    },
+    onError: () => {
+      showToast("임시저장에 실패했습니다. 잠시후에 시도해주세요.", false);
+    },
+    onSettled: () => {
+      setSaveDiaryDraft(false);
+    },
+  });
+
+  useEffect(() => {
+    if (!saveDiaryDraft) return;
+    const saveDiaryDraftFunc = async () => {
+      const formData = new FormData();
+
+      const request: Diary = {
+        title: getValues("title"),
+        content: getValues("content"),
+        date: getValues("date"),
+        isPublic: getValues("isPublic") === "PUBLIC" ? true : false,
+      };
+
+      const videoData = getValues("video");
+      //video가 있다면 백엔드에 등록 후 응답id를 formData에 추가
+      if (videoData) {
+        request.uploadedVideoIds = [videoData];
+      }
+
+      const blob = new Blob([JSON.stringify(request)], { type: "application/json" });
+      formData.append("request", blob);
+
+      if (diaryImages) {
+        diaryImages.forEach((v) => formData.append("images", v.file));
+      }
+
+      postDiaryDraftMutation(formData);
+    };
+    saveDiaryDraftFunc();
+  }, [saveDiaryDraft]);
+
+  //임시저장 불러오기
+  useEffect(() => {
+    if (!loadDiaryDraft) return;
+    const loadDiaryDarft = async () => {
+      const diary: GetDiaryDraftResponse = await getDiaryDraft();
+      if (diary) {
+        setValue("title", diary.title);
+        setValue("content", diary.content);
+        setValue("date", diary.date.replaceAll(".", "-"));
+        setOldImages([...diary.images]);
+        setOldVideo([...diary.videos]);
+        setValue("isPublic", diary.isPublic ? "PUBLIC" : null);
+      }
+      setLoadDiaryDraft(false); //초기화
+    };
+    loadDiaryDarft();
+  }, [loadDiaryDraft]);
 
   //일기 생성
   const {
@@ -39,7 +109,7 @@ const CreateForm = ({ petId }: { petId: number }) => {
       setDiaryImages([]);
       setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ["diaries", petId] });
-        router.push("/diary/my-pet");
+        router.back();
       }, 1000); //썸네일 서버에서 완성되는 동안 기다려줌
     },
     onError: () => {
@@ -55,6 +125,11 @@ const CreateForm = ({ petId }: { petId: number }) => {
     watch,
     handleSubmit,
   } = useForm<FormInput>({ mode: "onChange", defaultValues: { date: getPrettyToday(), isPublic: "PUBLIC" } });
+
+  //제목, 내용이 있을시에만 임시저장할 수 있도록 값을 watch
+  useEffect(() => {
+    setDiaryData({ title: watch("title"), content: watch("content") });
+  }, [watch("title"), watch("content")]);
 
   const [diaryImages, setDiaryImages] = useAtom(diaryImagesAtom);
 
@@ -92,14 +167,14 @@ const CreateForm = ({ petId }: { petId: number }) => {
         >
           <TitleInput register={register} watch={watch} errors={errors} />
           <DateInput register={register} setValue={setValue} getValue={getValues} />
-          <ImageInput register={register} setValue={setValue} />
-          <VideoInput register={register} setValue={setValue} />
+          <ImageInput register={register} setValue={setValue} oldMedia={oldImages} />
+          <VideoInput register={register} setValue={setValue} oldMedia={oldVideo} />
           <ContentInput register={register} watch={watch} errors={errors} />
           <PublicPrivateToggle register={register} watch={watch} setValue={setValue} />
 
           <button className={styles.button}>작성하기</button>
         </form>
-        {(isPending || isSuccess) && <Loading />}
+        {(isPending || isSuccess || isDiarydDraftPending) && <Loading />}
       </div>
     </>
   );

--- a/app/diary/_components/Form/CreateForm/index.tsx
+++ b/app/diary/_components/Form/CreateForm/index.tsx
@@ -131,6 +131,10 @@ const CreateForm = ({ petId }: { petId: number }) => {
     setDiaryData({ title: watch("title"), content: watch("content") });
   }, [watch("title"), watch("content")]);
 
+  useEffect(() => {
+    console.log("video ", getValues("video"));
+  }, [watch("video")]);
+
   const [diaryImages, setDiaryImages] = useAtom(diaryImagesAtom);
 
   const router = useRouter();

--- a/app/diary/_components/Form/CreateForm/index.tsx
+++ b/app/diary/_components/Form/CreateForm/index.tsx
@@ -30,7 +30,7 @@ interface Diary {
 const CreateForm = ({ petId }: { petId: number }) => {
   const queryClient = useQueryClient();
   const [oldImages, setOldImages] = useState<DiaryMediaType[] | DiaryDraftMediaType[]>([]);
-  const [oldVideo, setOldVideo] = useState<DiaryMediaType[] | DiaryDraftMediaType[]>([]);
+  const [draftVideo, setDraftVideo] = useState<DiaryDraftMediaType[]>([]);
   const [loadDiaryDraft, setLoadDiaryDraft] = useAtom(loadDiaryDraftAtom);
   const [saveDiaryDraft, setSaveDiaryDraft] = useAtom(saveDiaryDraftAtom);
   const [, setDiaryData] = useAtom(diaryDataAtom);
@@ -90,9 +90,8 @@ const CreateForm = ({ petId }: { petId: number }) => {
         setValue("content", diary.content);
         setValue("date", diary.date.replaceAll(".", "-"));
         setOldImages([...diary.images]);
-        setOldVideo([...diary.videos]);
+        setDraftVideo([...diary.videos]);
         setValue("isPublic", diary.isPublic ? "PUBLIC" : null);
-        deleteDiaryDraft();
       }
       setLoadDiaryDraft(false); //초기화
     };
@@ -173,7 +172,7 @@ const CreateForm = ({ petId }: { petId: number }) => {
           <TitleInput register={register} watch={watch} errors={errors} />
           <DateInput register={register} setValue={setValue} getValue={getValues} />
           <ImageInput register={register} setValue={setValue} oldMedia={oldImages} />
-          <VideoInput register={register} setValue={setValue} oldMedia={oldVideo} />
+          <VideoInput register={register} setValue={setValue} draftMedia={draftVideo} />
           <ContentInput register={register} watch={watch} errors={errors} />
           <PublicPrivateToggle register={register} watch={watch} setValue={setValue} />
 

--- a/app/diary/_components/Input/ImageInput/index.tsx
+++ b/app/diary/_components/Input/ImageInput/index.tsx
@@ -18,7 +18,7 @@ export interface ImagesType {
 }
 const MAX_IMAGES = 10;
 
-export interface InputProps {
+interface InputProps {
   register: UseFormRegister<FormInput>;
   setValue: UseFormSetValue<FormInput>;
   oldMedia?: DiaryMediaType[] | DiaryDraftMediaType[];

--- a/app/diary/_components/Input/ImageInput/index.tsx
+++ b/app/diary/_components/Input/ImageInput/index.tsx
@@ -1,7 +1,7 @@
 import Modal from "@/app/_components/Modal";
 import { useModal } from "@/app/_hooks/useModal";
 import { diaryImagesAtom } from "@/app/_states/atom";
-import { DiaryMediaType } from "@/app/_types/diary/type";
+import { DiaryDraftMediaType, DiaryMediaType } from "@/app/_types/diary/type";
 import { FormInput } from "@/app/diary/_components/Form/EditForm";
 import { DragDropContext, Draggable, DropResult, Droppable } from "@hello-pangea/dnd";
 import { useAtom } from "jotai";
@@ -21,7 +21,7 @@ const MAX_IMAGES = 10;
 export interface InputProps {
   register: UseFormRegister<FormInput>;
   setValue: UseFormSetValue<FormInput>;
-  oldMedia?: DiaryMediaType[];
+  oldMedia?: DiaryMediaType[] | DiaryDraftMediaType[];
 }
 const convertURLtoFile = async (url: string) => {
   const response = await fetch(url);
@@ -34,7 +34,7 @@ const convertURLtoFile = async (url: string) => {
 const ImageInput = ({ register, setValue, oldMedia }: InputProps) => {
   const [images, setImages] = useAtom(diaryImagesAtom);
 
-  const handleOldMedia = async (oldMedia: DiaryMediaType[]) => {
+  const handleOldMedia = async (oldMedia: DiaryMediaType[] | DiaryDraftMediaType[]) => {
     for (const v of oldMedia) {
       const file = await convertURLtoFile(process.env.NEXT_PUBLIC_IMAGE_PREFIX + v.path);
       setImages((prev) => [...prev, { name: file.name, file: file, url: URL.createObjectURL(file) }]);

--- a/app/diary/_components/Input/VideoInput/index.tsx
+++ b/app/diary/_components/Input/VideoInput/index.tsx
@@ -39,7 +39,7 @@ const VideoInput = ({ register, setValue, oldMedia }: InputProps) => {
   const handleVideoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files || !files[0]) return;
-
+    console.log("video", e);
     setPreviewVideo(URL.createObjectURL(files[0]));
 
     if (oldData && oldData.length > 0) {

--- a/app/diary/create/BackHeader.tsx
+++ b/app/diary/create/BackHeader.tsx
@@ -1,0 +1,32 @@
+"use client";
+import * as styles from "@/app/_components/BackHeader/style.css";
+import { useModal } from "@/app/_hooks/useModal";
+import { diaryDataAtom } from "@/app/_states/atom";
+import DiarySaveModal from "@/app/diary/_components/DiaryDraftModal/DiarySaveModal";
+import BackIcon from "@/public/icons/chevron-left.svg?url";
+import { useAtom } from "jotai";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+
+const BackHeader = () => {
+  const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
+  const [diaryData] = useAtom(diaryDataAtom);
+  const router = useRouter();
+  return (
+    <>
+      <header className={styles.header} style={{ top: "0" }}>
+        <h1 className={styles.title}>육아일기 글작성</h1>
+        <div
+          className={styles.backIcon}
+          onClick={() => {
+            diaryData.title && diaryData.content ? openModalFunc() : router.back();
+          }}
+        >
+          <Image src={BackIcon} alt="backward icon" width={25} height={25} />
+        </div>
+      </header>
+      {isModalOpen && <DiarySaveModal closeModalFunc={closeModalFunc} />}
+    </>
+  );
+};
+export default BackHeader;

--- a/app/diary/create/BackHeader.tsx
+++ b/app/diary/create/BackHeader.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { deleteDiaryDraft, getDiaryDraftCheck } from "@/app/_api/diary";
 import * as styles from "@/app/_components/BackHeader/style.css";
 import { useModal } from "@/app/_hooks/useModal";
 import { diaryDataAtom } from "@/app/_states/atom";
@@ -7,11 +8,21 @@ import BackIcon from "@/public/icons/chevron-left.svg?url";
 import { useAtom } from "jotai";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
 const BackHeader = () => {
   const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const [diaryData] = useAtom(diaryDataAtom);
   const router = useRouter();
+  const [hasDiaryDraft, setHasDiaryDraft] = useState(false);
+  useEffect(() => {
+    const loadHasDiaryDraft = async () => {
+      const { hasDiaryDraft } = await getDiaryDraftCheck();
+      setHasDiaryDraft(hasDiaryDraft);
+    };
+    loadHasDiaryDraft();
+  }, []);
+
   return (
     <>
       <header className={styles.header} style={{ top: "0" }}>
@@ -19,6 +30,7 @@ const BackHeader = () => {
         <div
           className={styles.backIcon}
           onClick={() => {
+            if (hasDiaryDraft) deleteDiaryDraft();
             diaryData.title && diaryData.content ? openModalFunc() : router.back();
           }}
         >

--- a/app/diary/create/page.tsx
+++ b/app/diary/create/page.tsx
@@ -5,16 +5,16 @@ import CreateForm from "@/app/diary/_components/Form/CreateForm";
 import BackHeader from "@/app/diary/create/BackHeader";
 import { cookies } from "next/headers";
 import { Suspense } from "react";
+import Spinner from "@/app/_components/Spinner";
 
 const CreatePage = async () => {
   const petId = Number(cookies().get("petId")?.value);
   const { hasDiaryDraft } = await getDiaryDraftCheck();
-
   return (
     <div className={root}>
       <BackHeader />
       <div className={container}>
-        <Suspense fallback={<div>Loading</div>}>
+        <Suspense fallback={<Spinner />}>
           {hasDiaryDraft && <DiaryLoadModal />}
           <CreateForm petId={petId} />
         </Suspense>

--- a/app/diary/create/page.tsx
+++ b/app/diary/create/page.tsx
@@ -1,23 +1,15 @@
-import { getDiaryDraftCheck } from "@/app/_api/diary";
 import { container, root } from "@/app/diary/(diary)/my-pet/style.css";
-import DiaryLoadModal from "@/app/diary/_components/DiaryDraftModal/DiaryLoadModal";
 import CreateForm from "@/app/diary/_components/Form/CreateForm";
 import BackHeader from "@/app/diary/create/BackHeader";
 import { cookies } from "next/headers";
-import { Suspense } from "react";
-import Spinner from "@/app/_components/Spinner";
-
 const CreatePage = async () => {
   const petId = Number(cookies().get("petId")?.value);
-  const { hasDiaryDraft } = await getDiaryDraftCheck();
+
   return (
     <div className={root}>
       <BackHeader />
       <div className={container}>
-        <Suspense fallback={<Spinner />}>
-          {hasDiaryDraft && <DiaryLoadModal />}
-          <CreateForm petId={petId} />
-        </Suspense>
+        <CreateForm petId={petId} />
       </div>
     </div>
   );

--- a/app/diary/create/page.tsx
+++ b/app/diary/create/page.tsx
@@ -1,19 +1,25 @@
-import CreateForm from "@/app/diary/_components/Form/CreateForm";
-import { cookies } from "next/headers";
+import { getDiaryDraftCheck } from "@/app/_api/diary";
 import { container, root } from "@/app/diary/(diary)/my-pet/style.css";
-import BackHeader from "@/app/_components/BackHeader";
+import DiaryLoadModal from "@/app/diary/_components/DiaryDraftModal/DiaryLoadModal";
+import CreateForm from "@/app/diary/_components/Form/CreateForm";
+import BackHeader from "@/app/diary/create/BackHeader";
+import { cookies } from "next/headers";
+import { Suspense } from "react";
 
-const CreatePage = () => {
+const CreatePage = async () => {
   const petId = Number(cookies().get("petId")?.value);
+  const { hasDiaryDraft } = await getDiaryDraftCheck();
 
   return (
     <div className={root}>
-      <BackHeader title="육아일기 글작성" styleTop="0" />
+      <BackHeader />
       <div className={container}>
-        <CreateForm petId={petId} />
+        <Suspense fallback={<div>Loading</div>}>
+          {hasDiaryDraft && <DiaryLoadModal />}
+          <CreateForm petId={petId} />
+        </Suspense>
       </div>
     </div>
   );
 };
-
 export default CreatePage;


### PR DESCRIPTION
## 📌 관련 이슈
- close #354 

## 💻 주요 변경 사항
- 일기를 작성하다 뒤로갈 때 임시저장할지 물어봅니다.
- 일기 작성 페이지로 들어가면 임시저장한 데이터를 불러올지 물어봅니다.
- 임시저장한 데이터를 불러오고 삭제합니다.

서버 페이지에서 데이터를 fetch하여 빠르게 사용하려다가 next.js는 route를 매번 렌더링하지 않고 이전값을 cache해서 사용한다는 것을 알게되었습니다. 그 결과 데이터가 매번 fetch되지 않았고 최신 데이터가 항상 필요한 '임시저장'에는 적합하지 않아 결국 client 컴포넌트에서 구현했네요!
cache된 값을 revalidate하는 방법도 시도해봤으나 바로 페이지가 새로고침되면서 깜빡임 현상이 있어 그보다는 조금 느린 client컴포넌트를 채택했습니다.

## 📸 스크린샷
<img width="368" alt="스크린샷 2024-05-02 오후 8 57 53" src="https://github.com/ppp-team/my-pet-log/assets/144668146/9273d673-e866-4b9c-bef1-7b4783f671da">
<img width="368" alt="스크린샷 2024-05-02 오후 8 58 02" src="https://github.com/ppp-team/my-pet-log/assets/144668146/68d1342d-9742-437a-a919-20da2008b532">


## 📣 기타 문의(선택)
-
