### PR TITLE
[#362] fix : 소셜로그인 에러 테스트3 (next-auth)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,6 +5,15 @@ export function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname;
   const petId = request.cookies.get("petId");
 
+  const withoutWWWPathname = path.replace(/^\/(www\.)?/, "/");
+
+  // 소셜로그인 URL에서 www를 제거하도록 설정
+  if (path.startsWith("/api/auth/callback/kakao") || path.startsWith("/api/auth/callback/google")) {
+    return NextResponse.redirect(new URL(withoutWWWPathname, request.url));
+  }
+
+  // www를 제거한 경로로 리디렉션
+  if (path !== withoutWWWPathname) return NextResponse.redirect(new URL(withoutWWWPathname, request.url));
   if (accessToken) {
     if (path === "/" || path.startsWith("/login") || path.startsWith("/signup")) return NextResponse.redirect(new URL("/home", request.url));
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #362 

## 💻 주요 변경 사항
- api/auth/callback/소셜 에서만 www가 뿅 생기는 현상 발견!!!!!!!!!! www가 붙으면 다른 사이트로 인식을 해서 도메인 오류가 나타나는 것으로 추정 
→ 미들웨어로 특정 경로에서 www제거한 후 라우팅하도록 설정 

## 📸 스크린샷

## 📣 기타 문의(선택)
- 이번엔 될까......? → 안됨

![image](https://github.com/ppp-team/my-pet-log/assets/144667455/2b865e11-17ab-4ddf-a77d-4632e85a301b)
