### PR TITLE
[#298] fix : 없는 사용자 초대 시 에러메시지

### DIFF
--- a/app/settings/_components/InvitationForm/index.tsx
+++ b/app/settings/_components/InvitationForm/index.tsx
@@ -25,10 +25,10 @@ const InvitationForm = ({ petId }: { petId: number }) => {
       showToast("초대 완료!", true);
       queryClient.invalidateQueries({ queryKey: ["my-invitations", petId] });
     },
-    onError: (error: any) => {
+    onError: () => {
       setError("inputValue", {
         type: "manual",
-        message: error.message,
+        message: "초대한 사용자를 찾을 수 없습니다.",
       });
     },
   });


### PR DESCRIPTION
## 📌 관련 이슈
- close #298

## 💻 주요 변경 사항
- 없는 사용자 초대 시 에러메시지 띄우는 부분.. 로컬에선 잘 작동하는데 배포환경에서 문제가 되더라구요. 찾아보니까 무슨 버셸 배포문제 때문에 그렇다고들 하는데 버셸로 배포한 거 아닌데...원인 찾아봐도 모르겠어서 일단 조금 고쳐봤어요..! 배포환경에서 다시 확인해봐야할 거 같아요

## 📸 스크린샷

## 📣 기타 문의(선택)
-
