### PR TITLE
[#391] Feat : 소셜로그인을 구분하는 loginType 추가에 따른 로직 수정

### DIFF
--- a/app/(auth)/oauth/callback/[provider]/page.tsx
+++ b/app/(auth)/oauth/callback/[provider]/page.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect } from "react";
 export default function OAuth() {
   const pathname = usePathname();
   const provider = pathname.split("/").at(-1);
+  const loginType = provider!.toUpperCase() as "KAKAO" | "GOOGLE";
   const searchParam = useSearchParams();
   const code = searchParam.get("code");
 
@@ -57,7 +58,7 @@ export default function OAuth() {
         email = emailRes.data.email;
       }
 
-      const res = (await postSocial({ email })) as any;
+      const res = await postSocial({ email, loginType });
       if (res) {
         router.push("/home");
       }

--- a/app/_api/auth/index.ts
+++ b/app/_api/auth/index.ts
@@ -9,6 +9,7 @@ interface FormData {
 
 interface SocialData {
   email?: string | null;
+  loginType?: "KAKAO" | "GOOGLE";
 }
 
 export const postLogin = async ({ email, password }: FormData) => {
@@ -31,10 +32,11 @@ export const postLogin = async ({ email, password }: FormData) => {
   }
 };
 
-export const postSocial = async ({ email }: SocialData) => {
+export const postSocial = async ({ email, loginType }: SocialData) => {
   try {
     const res = await instance.post("/auth/login/social", {
       email,
+      loginType,
     });
 
     if (res.status === 200) {

--- a/app/_components/Toast/style.css.ts
+++ b/app/_components/Toast/style.css.ts
@@ -2,6 +2,7 @@ import { globalStyle, style } from "@vanilla-extract/css";
 
 export const container = style({
   display: "flex",
+  justifyContent: "center",
   alignItems: "center",
   gap: "1rem",
 
@@ -11,7 +12,7 @@ export const container = style({
 });
 
 globalStyle(".Toastify__toast-container ", {
-  width: "30rem",
+  width: "35rem",
 
   bottom: "10rem",
   left: "50%",

--- a/app/_types/user/types.ts
+++ b/app/_types/user/types.ts
@@ -3,4 +3,5 @@ export interface UserType {
   email: string;
   nickname: string;
   profilePath: string | null;
+  loginType: "EMAIL" | "KAKAO" | "GOOGLE";
 }

--- a/app/settings/(account)/layout.tsx
+++ b/app/settings/(account)/layout.tsx
@@ -4,9 +4,24 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import * as styles from "@/app/settings/(account)/layout.css";
 import TitleHeader from "@/app/_components/TitleHeader";
+import { getMe } from "@/app/_api/users";
+import { useQuery } from "@tanstack/react-query";
+import { UserType } from "@/app/_types/user/types";
+import { showToast } from "@/app/_components/Toast";
 
 export default function AccountLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const { data: user } = useQuery<UserType>({
+    queryKey: ["me"],
+    queryFn: () => getMe(),
+  });
+
+  const isEmailLogin = user?.loginType === "EMAIL";
+
+  const handleUnauthorized = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    showToast("이메일로 가입한 회원만 접근할 수 있습니다.", false);
+  };
 
   return (
     <section>
@@ -18,10 +33,16 @@ export default function AccountLayout({ children }: { children: React.ReactNode 
               프로필 설정
             </Link>
           </li>
-          <li className={`${pathname === "/settings/password" ? styles.active : styles.noActive}`}>
-            <Link href="/settings/password" replace>
-              비밀번호 변경
-            </Link>
+          <li className={`${isEmailLogin && pathname === "/settings/password" ? styles.active : styles.noActive}`}>
+            {isEmailLogin ? (
+              <Link href="/settings/password" replace>
+                <a>비밀번호 변경</a>
+              </Link>
+            ) : (
+              <Link href="#" onClick={handleUnauthorized}>
+                비밀번호 변경
+              </Link>
+            )}
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
## 📌 관련 이슈
- close # 추수 수정예정

## 💻 주요 변경 사항

- [x] 이메일 로그인 / 소셜로그인 두 가지로만 회원 분류중 → 이메일 로그인 / 소셜로그인 (구글 / 카카오) 로 세분화
     → 이메일 가입은 백엔드에서 분류(프론트 코드수정 없음), 소셜 가입은 post 값에 `loginType` 추가 

- [x]  이제 getMe(내 정보 조회)에 loginType도 추가로 함께 전달됩니당
     → getMe에 들어있는 loginType으로 분기 처리 해서 소셜로그인인 경우에는 `비밀번호 변경 페이지` 접근 못하고 안내 토스트


## 📸 스크린샷
![2024-05-13 19;49;00](https://github.com/ppp-team/my-pet-log/assets/144667455/5a8155d1-128e-44f4-b0ea-10acf100e63e)


## 📣 기타 문의(선택)
- 소셜로그인 이용자는 비밀번호가 없기 때문에 비밀번호 변경 페이지에 접근하지 못하도록 막은 것입니당 
- 근데 토스트 글씨가 좀 치우쳐보여서 그냥,,,, 쉽게쉽게,,,  justifyContent: "center", 이걸로 중앙 정렬 했어효,,,,  ㅠ ㅠ ㅠ  수정 요청 겸허히 받습니다...