### PR TITLE
[#393] fix : pet을 선택하면 header에 반영 안 되는 이슈 해결

### DIFF
--- a/app/_components/SelectPet/index.tsx
+++ b/app/_components/SelectPet/index.tsx
@@ -8,19 +8,23 @@ import calculateAge from "@/app/_utils/calculateAge";
 import { getImagePath } from "@/app/_utils/getPetImagePath";
 import ParticipatePetGroupModal from "@/app/home/_components/ParticipatePetGroupModal/ParticipatePetGroupModal";
 import AddIcon from "@/public/icons/add.svg?url";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 const Pet = ({ pet, path }: { pet: PetType; path: string }) => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   return (
     <div
       className={styles.container}
       onClick={async () => {
         try {
           await editPetRep(pet.petId);
+          queryClient.invalidateQueries({
+            queryKey: ["pets"],
+          });
           router.push(path);
         } catch {
           console.error("대표 반려동물 등록 실패");


### PR DESCRIPTION
## 📌 관련 이슈
- close #393 

## 💻 주요 변경 사항
- select-pet 페이지에서 pet을 선택할 때 cookie에는 petId가 잘 들어가지만 헤더는 변하지 않는 이슈가 있었어요(방금 발견)
- 헤더는 pet data의 repStatus로 동작하는데 pet data를 새로 가져오지 않기 때문 => invalidateQuery("pets") 해결

## 📸 스크린샷

## 📣 기타 문의(선택)
-
