### PR TITLE
Fix : 동물 등록 무한루프 에러 수정

### DIFF
--- a/app/_components/PetRegister/index.tsx
+++ b/app/_components/PetRegister/index.tsx
@@ -71,19 +71,18 @@ const PetRegister = () => {
       const response = await postPet({ formData: data });
       return response;
     },
-    onSuccess: () => {
-      openModalFunc();
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["pets"] });
+      handleCloseModal();
     },
   });
 
   const handleCloseModal = async () => {
-    await queryClient.invalidateQueries({ queryKey: ["pets"] });
     closeModalFunc();
     if (pathname === "/settings/pet-register") {
-      router.push("/settings");
-    }
-    if (pathname === "/pet-register") {
-      router.push("/home");
+      router.replace("/settings"); // replace 사용하여 페이지 새로고침 없이 이동
+    } else if (pathname === "/pet-register") {
+      router.replace("/home"); // replace 사용하여 페이지 새로고침 없이 이동
     }
   };
 


### PR DESCRIPTION
## 📌 관련 이슈
- close #이슈번호

## 💻 주요 변경 사항

- [x] 동물 등록 무한루프 - 새 동물 등록 전에 getPets 함수 실행되서 순서 때문에 제대로 작동되지 않는 부분 해결

1. postPet이 성공하면 queryClient.invalidateQueries를 사용하여 pets 쿼리를 무효화하고 다시 가져오도록 수정
2. 페이지 이동 후에 getPets가 최신 데이터를 가져올 수 있도록 router.replace를 사용하여 페이지를 새로고침하지 않고 이동


## 📸 스크린샷


https://github.com/ppp-team/my-pet-log/assets/133554119/8a8d2d9c-4689-4f68-be70-58130733fdf7



## 📣 기타 문의(선택)
-
